### PR TITLE
Gate playtest requests on the live Playtests store catalog

### DIFF
--- a/FreePackages.Tests/Filters.cs
+++ b/FreePackages.Tests/Filters.cs
@@ -447,4 +447,129 @@ public class Filters {
 		Assert.IsTrue(PackageFilter.IsAppWantedByFilter(app, defaultFilter));
 		Assert.IsFalse(PackageFilter.IsAppIgnoredByFilter(app, defaultFilter));
 	}
+
+	// IsRedeemableApp / IsRedeemablePackage are the ownership + country + must-own gates that run
+	// before a package/app is queued for activation. These tests build focused userdata/userinfo
+	// (country and owned sets) without touching the ASF runtime.
+	// Future work: ActivationQueue.HandleResult needs a live Bot/ASF runtime and is not covered here.
+
+	private static string BuildUserDataJson(IEnumerable<uint>? ownedApps = null, IEnumerable<uint>? ownedPackages = null) {
+		string apps = ownedApps != null ? string.Join(",", ownedApps) : "";
+		string packages = ownedPackages != null ? string.Join(",", ownedPackages) : "";
+
+		return $"{{\"rgOwnedPackages\":[{packages}],\"rgOwnedApps\":[{apps}],\"rgIgnoredApps\":{{}},\"rgExcludedTags\":[],\"rgExcludedContentDescriptorIDs\":[],\"rgWishlist\":[],\"rgFollowedApps\":[]}}";
+	}
+
+	private void SetUserDetails(string country, IEnumerable<uint>? ownedApps = null, IEnumerable<uint>? ownedPackages = null) {
+		PackageFilter.UpdateUserDetails(BuildUserDataJson(ownedApps, ownedPackages).ToJsonObject<Steam.UserData>(), new Steam.UserInfo { CountryCode = country });
+	}
+
+	[TestMethod]
+	public void CanRedeemAppByRestrictedCountry() {
+		// app_with_restricted_countries: common/restricted_countries = "CN,DE"
+		var app = new FilterableApp(KeyValue.LoadAsText("app_with_restricted_countries.txt"));
+
+		SetUserDetails("US");
+		Assert.IsTrue(PackageFilter.IsRedeemableApp(app));
+
+		SetUserDetails("DE");
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+
+		SetUserDetails("CN");
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+
+		// Country list match is case-insensitive
+		SetUserDetails("de");
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+	}
+
+	[TestMethod]
+	public void CanRedeemAppByPurchaseRestrictedCountry() {
+		// app_with_purchase_restricted_countries (Mabinogi): allowpurchasefromrestrictedcountries=1,
+		// purchaserestrictedcountries="US CA MX NZ AU" -> redeemable only inside that list
+		var app = new FilterableApp(KeyValue.LoadAsText("app_with_purchase_restricted_countries.txt"));
+
+		SetUserDetails("US");
+		Assert.IsTrue(PackageFilter.IsRedeemableApp(app));
+
+		SetUserDetails("DE");
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+	}
+
+	[TestMethod]
+	public void CanRedeemAppByAlreadyOwned() {
+		var app = new FilterableApp(KeyValue.LoadAsText("app_with_restricted_countries.txt"));
+
+		// Owned by the bot -> not redeemable
+		SetUserDetails("US", ownedApps: new uint[] { 1245610 });
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+
+		// ignoreAlreadyOwned bypasses the ownership gate
+		Assert.IsTrue(PackageFilter.IsRedeemableApp(app, ignoreAlreadyOwned: true));
+	}
+
+	[TestMethod]
+	public void CanRedeemAppByMustOwn() {
+		// app_with_required_app: mustownapptopurchase=1086940
+		var app = new FilterableApp(KeyValue.LoadAsText("app_with_required_app.txt"));
+
+		// Missing the required app -> not redeemable
+		SetUserDetails("US");
+		Assert.IsFalse(PackageFilter.IsRedeemableApp(app));
+
+		// Owning the required app -> redeemable
+		SetUserDetails("US", ownedApps: new uint[] { 1086940 });
+		Assert.IsTrue(PackageFilter.IsRedeemableApp(app));
+
+		// includedAppIDs also satisfies the must-own gate without owning it
+		SetUserDetails("US");
+		Assert.IsTrue(PackageFilter.IsRedeemableApp(app, includedAppIDs: new HashSet<uint> { 1086940 }));
+	}
+
+	[TestMethod]
+	public void CanRedeemPackageByRestrictedCountry() {
+		// package 178: restrictedcountries="DE", onlyallowrestrictedcountries=1
+		var package = new FilterablePackage(KeyValue.LoadAsText("package_with_restricted_countries.txt"));
+		// PackageContents must be populated, or IsRedeemablePackage short-circuits on
+		// "already own all apps" (PackageContents.All over an empty set is vacuously true).
+		package.AddPackageContents(new List<KeyValue>() { KeyValue.LoadAsText("package_with_single_app_app_1.txt") });
+
+		// DE is in the restricted list and only-allowed -> redeemable
+		SetUserDetails("DE");
+		Assert.IsTrue(PackageFilter.IsRedeemablePackage(package));
+
+		// US is not allowed -> not redeemable
+		SetUserDetails("US");
+		Assert.IsFalse(PackageFilter.IsRedeemablePackage(package));
+	}
+
+	[TestMethod]
+	public void CanRedeemPackageByPurchaseRestrictedCountry() {
+		// package 1890: purchaserestrictedcountries="US CA MX PR", allowpurchasefromrestrictedcountries=1
+		var package = new FilterablePackage(KeyValue.LoadAsText("package_with_purchase_restricted_countries.txt"));
+		package.AddPackageContents(new List<KeyValue>() { KeyValue.LoadAsText("package_with_single_app_app_1.txt") });
+
+		// US in the purchase list -> redeemable
+		SetUserDetails("US");
+		Assert.IsTrue(PackageFilter.IsRedeemablePackage(package));
+
+		// DE outside the purchase list -> not redeemable
+		SetUserDetails("DE");
+		Assert.IsFalse(PackageFilter.IsRedeemablePackage(package));
+	}
+
+	[TestMethod]
+	public void CanRedeemPackageByAlreadyOwned() {
+		// package 44911: NoCost, no hard country restriction (purchase-restricted to RU only,
+		// allowpurchasefromrestrictedcountries=0) -> redeemable from US
+		var package = new FilterablePackage(KeyValue.LoadAsText("package_which_is_no_cost.txt"));
+		package.AddPackageContents(new List<KeyValue>() { KeyValue.LoadAsText("package_with_single_app_app_1.txt") });
+
+		// Owning the package -> not redeemable
+		SetUserDetails("US", ownedPackages: new uint[] { 44911 });
+		Assert.IsFalse(PackageFilter.IsRedeemablePackage(package));
+
+		// ignoreAlreadyOwned bypasses the ownership gate
+		Assert.IsTrue(PackageFilter.IsRedeemablePackage(package, ignoreAlreadyOwned: true));
+	}
 }

--- a/FreePackages.Tests/PlaytestCatalog.cs
+++ b/FreePackages.Tests/PlaytestCatalog.cs
@@ -89,6 +89,56 @@ public class PlaytestCatalogTests {
 		Assert.AreEqual(0, botCache.WaitlistedPlaytests.Count);
 	}
 
+	// IsUnconstrainedAllPlaytestsFilter gates the proactive catalog path: it must be
+	// true only for a filter that accepts every playtest (PlaytestMode All, nothing else
+	// set), so the catalog path — which has only BASE appIDs and can't honor any finer
+	// filter — never bypasses the user's filters. Any constraint falls back to the PICS
+	// path (HandlePlaytest), which resolves metadata and applies the filter first.
+	[TestMethod]
+	public void IsUnconstrainedAllPlaytestsFilterAcceptsAllOnlyConfig() {
+		// A filter with only PlaytestMode = All. IgnoredTypes defaults to {"Demo"}, which
+		// never rejects a playtest (playtests are not demos), so the default is allowed.
+		Assert.IsTrue(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All }));
+
+		// An empty IgnoredTypes is allowed too.
+		Assert.IsTrue(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredTypes = new HashSet<string>() }));
+	}
+
+	[TestMethod]
+	public void IsUnconstrainedAllPlaytestsFilterRejectsPlaytestModeOtherThanAll() {
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.None }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.Unlimited }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.Limited }));
+	}
+
+	[TestMethod]
+	public void IsUnconstrainedAllPlaytestsFilterRejectsAnyOtherConstraint() {
+		// All mode plus any app-level constraint -> fall back to the PICS path.
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, Types = new HashSet<string> { "Game" } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, Categories = new HashSet<uint> { 1 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, Tags = new HashSet<uint> { 19 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredAppIDs = new HashSet<uint> { 700 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredTags = new HashSet<uint> { 19 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredCategories = new HashSet<uint> { 1 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredContentDescriptors = new HashSet<uint> { 2 } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, ImportStoreFilters = true }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoreFreeWeekends = true }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, MinReviewScore = 80 }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, Languages = new HashSet<string> { "english" } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, NoCostOnly = true }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, Systems = new HashSet<string> { "linux" } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, WishlistOnly = true }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, MaxDaysOld = 30 }));
+	}
+
+	[TestMethod]
+	public void IsUnconstrainedAllPlaytestsFilterTreatsNonDemoIgnoredTypeAsConstraint() {
+		// The default {"Demo"} is allowed, but any other ignored type suppresses the
+		// proactive path, since the catalog can't tell whether it would reject a playtest.
+		Assert.IsTrue(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredTypes = new HashSet<string> { "Demo" } }));
+		Assert.IsFalse(PackageFilter.IsUnconstrainedAllPlaytestsFilter(new FilterConfig { PlaytestMode = EPlaytestMode.All, IgnoredTypes = new HashSet<string> { "Beta" } }));
+	}
+
 	private static HashSet<uint> BuildSet(int count) {
 		HashSet<uint> set = new(count);
 

--- a/FreePackages.Tests/PlaytestCatalog.cs
+++ b/FreePackages.Tests/PlaytestCatalog.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FreePackages.Tests;
+
+[TestClass]
+[DeploymentItem("TestData")]
+public class PlaytestCatalogTests {
+	// Parser: the search response lists the BASE game appID in data-ds-appid, which is
+	// exactly the value the plugin posts to /ajaxrequestplaytestaccess/<id> and stores
+	// as app.Parent.ID. These tests cover the parsing without touching the network.
+	[TestMethod]
+	public void CanParsePlaytestCatalogAppIDs() {
+		string resultsHtml = File.ReadAllText("playtest_search_results.txt");
+
+		HashSet<uint> appIDs = PlaytestCatalog.ParseAppIDs(resultsHtml);
+
+		// Three distinct real appIDs; duplicate 1873120 collapsed, id 0 ignored.
+		Assert.IsTrue(appIDs.SetEquals(new uint[] { 1873120, 2385860, 16792 }));
+		Assert.IsFalse(appIDs.Contains(0), "appID 0 must not be added to the live set");
+	}
+
+	[TestMethod]
+	public void CanParsePageRejectsUnusableResponse() {
+		// success != 1 -> the page is unusable, the whole fetch must abort (null).
+		Assert.IsNull(PlaytestCatalog.ParsePage(new PlaytestCatalog.SearchResults(success: 0, totalCount: 100, resultsHtml: "<a data-ds-appid=\"1\">")));
+
+		// null page -> unusable.
+		Assert.IsNull(PlaytestCatalog.ParsePage(null));
+
+		// success == 1 with no appids -> empty but usable (end-of-list page).
+		HashSet<uint>? empty = PlaytestCatalog.ParsePage(new PlaytestCatalog.SearchResults(success: 1, totalCount: 0, resultsHtml: "<div>no results</div>"));
+		Assert.IsNotNull(empty);
+		Assert.AreEqual(0, empty!.Count);
+	}
+
+	// IsFetchComplete is the safety net that decides whether a fetch is safe to prune
+	// from. A failed/empty/incomplete fetch MUST report false so DoUpdate keeps the
+	// previous live set and never wipes RequestedPlaytests (which would re-request the
+	// whole catalog on a network blip or a Steam markup change).
+	[TestMethod]
+	public void IsFetchCompleteRejectsIncompleteFetches() {
+		// Healthy fetch: parsed roughly what Steam reports.
+		Assert.IsTrue(PlaytestCatalog.IsFetchComplete(new HashSet<uint> { 1, 2, 3, 4 }, totalCount: 4));
+		Assert.IsTrue(PlaytestCatalog.IsFetchComplete(BuildSet(2807), totalCount: 2807));
+
+		// Empty fetch (nothing parsed — e.g. markup changed) -> never complete.
+		Assert.IsFalse(PlaytestCatalog.IsFetchComplete(new HashSet<uint>(), totalCount: 2807));
+
+		// total_count 0 -> never complete.
+		Assert.IsFalse(PlaytestCatalog.IsFetchComplete(BuildSet(10), totalCount: 0));
+
+		// Parsed far fewer than total_count (less than half) -> likely markup breakage.
+		Assert.IsFalse(PlaytestCatalog.IsFetchComplete(BuildSet(100), totalCount: 2807));
+	}
+
+	// Prune: a playtest that left the catalog is removed from RequestedPlaytests and
+	// WaitlistedPlaytests; one that stayed is kept. A playtest that re-opens later
+	// re-enters the catalog, was pruned while absent, and is requested again.
+	[TestMethod]
+	public void PruneRemovesPlaytestsThatLeftLiveSet() {
+		BotCache botCache = new();
+
+		botCache.AddRequestedPlaytest(100); // leaves the catalog
+		botCache.AddRequestedPlaytest(200); // stays live
+		botCache.AddWaitlistedPlaytest(300); // leaves
+		botCache.AddWaitlistedPlaytest(400); // stays live
+
+		botCache.PrunePlaytests(new HashSet<uint> { 200, 400, 500 });
+
+		Assert.IsFalse(botCache.RequestedPlaytests.Contains(100), "requested playtest that left must be pruned");
+		Assert.IsTrue(botCache.RequestedPlaytests.Contains(200), "requested playtest that stayed must be kept");
+		Assert.IsFalse(botCache.WaitlistedPlaytests.Contains(300), "waitlisted playtest that left must be pruned");
+		Assert.IsTrue(botCache.WaitlistedPlaytests.Contains(400), "waitlisted playtest that stayed must be kept");
+
+		// A re-opening (100 re-enters the live set) is requestable again because it was pruned.
+		Assert.IsFalse(botCache.RequestedPlaytests.Contains(100));
+	}
+
+	[TestMethod]
+	public void PruneHandlesEmptySets() {
+		BotCache botCache = new();
+
+		// Pruning a cache with no recorded playtests must not throw and must stay empty.
+		botCache.PrunePlaytests(new HashSet<uint> { 1, 2, 3 });
+
+		Assert.AreEqual(0, botCache.RequestedPlaytests.Count);
+		Assert.AreEqual(0, botCache.WaitlistedPlaytests.Count);
+	}
+
+	private static HashSet<uint> BuildSet(int count) {
+		HashSet<uint> set = new(count);
+
+		for (uint i = 1; i <= count; i++) {
+			set.Add(i);
+		}
+
+		return set;
+	}
+}

--- a/FreePackages.Tests/TestData/playtest_search_results.txt
+++ b/FreePackages.Tests/TestData/playtest_search_results.txt
@@ -1,0 +1,10 @@
+<div class="search_result_row ds_collapse_flag" data-ds-appid="1873120" data-ds-item-key="1873120" data-ds-tagids="[19,122]" style="background-image: url('https://cdn.akamai.steamstatic.com/steam/apps/1873120/capsule_236x166.jpg');">
+	<div class="col search_capsule"><img src="https://cdn.akamai.steamstatic.com/steam/apps/1873120/capsule_236x166.jpg" class="search_capsule"></div>
+</div>
+<a class="search_result_row ds_collapse_flag" data-ds-appid="2385860" data-ds-tagids="[3859,3859]" href="https://store.steampowered.com/app/2385860/Tekken_8_Open_Beta_Test/?snr=1_7_7_230_150_1">
+	<div class="col search_capsule"><img src="https://cdn.akamai.steamstatic.com/steam/apps/2385860/capsule_236x166.jpg"></div>
+</a>
+<a class="search_result_row" data-ds-appid="1873120" data-ds-tagids="[19]" href="https://store.steampowered.com/app/1873120">duplicate of the first row, must not double-count</a>
+<a class="search_result_row" data-ds-appid="0" href="https://store.steampowered.com/app/0">id 0 is not a real app, must be ignored</a>
+<a class="search_result_row" data-ds-appid="16792" href="https://store.steampowered.com/app/16792">third real playtest</a>
+<div class="search_pagination"></div>

--- a/FreePackages/Commands.cs
+++ b/FreePackages/Commands.cs
@@ -223,39 +223,16 @@ namespace FreePackages {
 			// https://github.com/JustArchiNET/ArchiSteamFarm/blob/d972c93072dd8d2bf0f2cecda3561dc3ba77a9ed/ArchiSteamFarm/Steam/Interaction/Commands.cs#L626C3-L626C34
 			StringBuilder response = new();
 
-			string[] entries = licenses.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
-			foreach (string entry in entries) {
-				uint gameID;
-				string type;
-
-				int index = entry.IndexOf('/', StringComparison.Ordinal);
-
-				if ((index > 0) && (entry.Length > index + 1)) {
-					if (!uint.TryParse(entry[(index + 1)..], out gameID) || (gameID == 0)) {
-						response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, nameof(gameID))));
-
-						continue;
-					}
-
-					type = entry[..index];
-				} else if (uint.TryParse(entry, out gameID) && (gameID > 0)) {
-					type = "SUB";
-				} else {
-					response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, nameof(gameID))));
+			foreach (ParsedLicenseEntry entry in ParseLicenseEntries(licenses)) {
+				if (entry.IsError) {
+					response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, "gameID")));
 
 					continue;
 				}
 
-				EPackageType packageType;
-				type = type.ToUpperInvariant();
-				if (type == "A" || type == "APP") {
-					packageType = EPackageType.RemoveApp;
-				} else {
-					packageType = EPackageType.RemoveSub;
-				}
+				EPackageType packageType = (entry.Type == "A" || entry.Type == "APP") ? EPackageType.RemoveApp : EPackageType.RemoveSub;
 
-				response.AppendLine(FormatBotResponse(bot, PackageHandler.Handlers[bot.BotName].ModifyRemovables(packageType, gameID)));
+				response.AppendLine(FormatBotResponse(bot, PackageHandler.Handlers[bot.BotName].ModifyRemovables(packageType, entry.GameID)));
 			}
 
 			return response.Length > 0 ? response.ToString() : null;
@@ -331,39 +308,16 @@ namespace FreePackages {
 			// https://github.com/JustArchiNET/ArchiSteamFarm/blob/d972c93072dd8d2bf0f2cecda3561dc3ba77a9ed/ArchiSteamFarm/Steam/Interaction/Commands.cs#L626C3-L626C34
 			StringBuilder response = new();
 
-			string[] entries = licenses.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
-			foreach (string entry in entries) {
-				uint gameID;
-				string type;
-
-				int index = entry.IndexOf('/', StringComparison.Ordinal);
-
-				if ((index > 0) && (entry.Length > index + 1)) {
-					if (!uint.TryParse(entry[(index + 1)..], out gameID) || (gameID == 0)) {
-						response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, nameof(gameID))));
-
-						continue;
-					}
-
-					type = entry[..index];
-				} else if (uint.TryParse(entry, out gameID) && (gameID > 0)) {
-					type = "SUB";
-				} else {
-					response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, nameof(gameID))));
+			foreach (ParsedLicenseEntry entry in ParseLicenseEntries(licenses)) {
+				if (entry.IsError) {
+					response.AppendLine(FormatBotResponse(bot, string.Format(CultureInfo.CurrentCulture, ArchiSteamFarm.Localization.Strings.ErrorIsInvalid, "gameID")));
 
 					continue;
 				}
 
-				EPackageType packageType;
-				type = type.ToUpperInvariant();
-				if (type == "A" || type == "APP") {
-					packageType = EPackageType.App;
-				} else {
-					packageType = EPackageType.Sub;
-				}
+				EPackageType packageType = (entry.Type == "A" || entry.Type == "APP") ? EPackageType.App : EPackageType.Sub;
 
-				response.AppendLine(FormatBotResponse(bot, PackageHandler.Handlers[bot.BotName].AddPackage(packageType, gameID, useFilter)));
+				response.AppendLine(FormatBotResponse(bot, PackageHandler.Handlers[bot.BotName].AddPackage(packageType, entry.GameID, useFilter)));
 			}
 
 			if (previousMethodName == nameof(Response)) {
@@ -459,6 +413,59 @@ namespace FreePackages {
 			}
 
 			return await ResponseRemoveFreePackages(bot, ArchiSteamFarm.Steam.Interaction.Commands.GetProxyAccess(bot, access, steamID), statusReporter, excludePlayed, removeAll).ConfigureAwait(false);
+		}
+
+		// Parses a comma-separated license list (e.g. "app/123, sub/456, 789") into typed
+		// entries, shared by ResponseDontRemove and ResponseQueueLicense. `Type` is the
+		// upper-cased prefix ("A"/"APP" or "SUB" — "SUB" is the default when no prefix is
+		// given); `IsError` marks an entry that failed to parse so the caller can emit the
+		// same localized error for each bad entry, preserving order and count.
+		private static List<ParsedLicenseEntry> ParseLicenseEntries(string licenses) {
+			List<ParsedLicenseEntry> entries = new();
+
+			string[] raw = licenses.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+			foreach (string entry in raw) {
+				uint gameID;
+				string type;
+
+				int index = entry.IndexOf('/', StringComparison.Ordinal);
+
+				if ((index > 0) && (entry.Length > index + 1)) {
+					if (!uint.TryParse(entry[(index + 1)..], out gameID) || (gameID == 0)) {
+						entries.Add(ParsedLicenseEntry.AsError());
+
+						continue;
+					}
+
+					type = entry[..index];
+				} else if (uint.TryParse(entry, out gameID) && (gameID > 0)) {
+					type = "SUB";
+				} else {
+					entries.Add(ParsedLicenseEntry.AsError());
+
+					continue;
+				}
+
+				entries.Add(ParsedLicenseEntry.AsOk(type.ToUpperInvariant(), gameID));
+			}
+
+			return entries;
+		}
+
+		private readonly struct ParsedLicenseEntry {
+			internal string Type { get; }
+			internal uint GameID { get; }
+			internal bool IsError { get; }
+
+			private ParsedLicenseEntry(string type, uint gameID, bool isError) {
+				Type = type;
+				GameID = gameID;
+				IsError = isError;
+			}
+
+			internal static ParsedLicenseEntry AsOk(string type, uint gameID) => new(type, gameID, false);
+			internal static ParsedLicenseEntry AsError() => new("", 0, true);
 		}
 
 		internal static string FormatStaticResponse(string response) => ArchiSteamFarm.Steam.Interaction.Commands.FormatStaticResponse(response);

--- a/FreePackages/Data/Cache/BotCache.cs
+++ b/FreePackages/Data/Cache/BotCache.cs
@@ -41,6 +41,14 @@ namespace FreePackages {
 		[JsonDisallowNull]
 		internal ConcurrentHashSet<uint> WaitlistedPlaytests { get; private set; } = new();
 
+		// BASE appIDs of playtests we've already POSTed /ajaxrequestplaytestaccess for in
+		// the current catalog-membership epoch. Suppresses re-requests while the playtest
+		// stays live; pruned (along with WaitlistedPlaytests) when a playtest leaves the
+		// catalog so a re-opening is caught. See PlaytestCatalog.
+		[JsonInclude]
+		[JsonDisallowNull]
+		internal ConcurrentHashSet<uint> RequestedPlaytests { get; private set; } = new();
+
 		[JsonInclude]
 		[JsonDisallowNull]
 		internal ConcurrentHashSet<uint> IgnoredApps { get; private set; } = new();
@@ -275,7 +283,33 @@ namespace FreePackages {
 
 		internal void AddWaitlistedPlaytest(uint appID) {
 			WaitlistedPlaytests.Add(appID);
-			
+
+			ScheduleSave();
+		}
+
+		internal void AddRequestedPlaytest(uint appID) {
+			RequestedPlaytests.Add(appID);
+
+			ScheduleSave();
+		}
+
+		// Drop playtests that are no longer in the live catalog. Called only on a
+		// successful, complete catalog fetch (see PlaytestCatalog.DoUpdate) — never on a
+		// failed or partial one, so a network blip or markup change can't wipe the
+		// suppression sets and re-request the whole catalog. A playtest that re-opens
+		// later re-enters the catalog, gets pruned out of these sets on the cycle where it
+		// was absent, and is requested again on the cycle where it returns.
+		internal void PrunePlaytests(HashSet<uint> liveSet) {
+			ArgumentNullException.ThrowIfNull(liveSet);
+
+			if (RequestedPlaytests.Count > 0) {
+				RequestedPlaytests.RemoveWhere(id => !liveSet.Contains(id));
+			}
+
+			if (WaitlistedPlaytests.Count > 0) {
+				WaitlistedPlaytests.RemoveWhere(id => !liveSet.Contains(id));
+			}
+
 			ScheduleSave();
 		}
 

--- a/FreePackages/Data/Cache/BotCache.cs
+++ b/FreePackages/Data/Cache/BotCache.cs
@@ -313,6 +313,30 @@ namespace FreePackages {
 			ScheduleSave();
 		}
 
+		// Remove playtest packages from the activation queue that are no longer in the live
+		// catalog. Without this, a playtest that was enqueued (pre-gate, or via the PICS path)
+		// and then closed would sit in the persisted queue and produce a 401 Invalid when it
+		// is finally claimed — one per stale entry, draining slowly under the activation
+		// rate limit. Pruning them here — only on a successful complete fetch, like
+		// PrunePlaytests — makes that cleanup instant and silent. Live playtests stay in the
+		// queue and are claimed normally (OK/Waitlisted). A playtest that re-opens later
+		// re-enters the catalog, is pruned out of RequestedPlaytests on the cycle it was
+		// absent, and is re-enqueued by OnPlaytestCatalogUpdated on the cycle it returns.
+		internal void PrunePlaytestPackages(HashSet<uint> liveSet) {
+			ArgumentNullException.ThrowIfNull(liveSet);
+
+			List<Package> stale = Packages.Where(x => x.Type == EPackageType.Playtest && !liveSet.Contains(x.ID)).ToList();
+			if (stale.Count == 0) {
+				return;
+			}
+
+			foreach (Package package in stale) {
+				Packages.Remove(package);
+			}
+
+			ScheduleSave();
+		}
+
 		internal void UpdateSeenPackages(List<SteamApps.LicenseListCallback.License> newLicenses) {
 			SeenPackages.UnionWith(newLicenses.Select(license => license.PackageID));
 

--- a/FreePackages/Data/Cache/BotCache.cs
+++ b/FreePackages/Data/Cache/BotCache.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Collections;
 using ArchiSteamFarm.Core;
@@ -50,8 +51,32 @@ namespace FreePackages {
 		private HashSet<uint> SeenPackageIDActivations = new();
 		private readonly object LockObject = new();
 
+		// Debounced save: a burst of mutations collapses into a single deferred write.
+		// SerializableFile already coalesces concurrent saves (SavingScheduled flag), but
+		// replacing Utilities.InBackground(Save) — which allocates a threadpool task per
+		// mutation — with a one-shot timer re-arm avoids tens of thousands of task
+		// allocations under a large PICS changelist. ASF exposes no shutdown hook for
+		// IBotModules, so a final flush on process exit is not possible from the plugin;
+		// worst case is losing mutations made in the last SaveDebounceDelay before an
+		// abrupt exit.
+		private Timer? SaveTimer;
+		private static readonly TimeSpan SaveDebounceDelay = TimeSpan.FromSeconds(5);
+
 		[JsonConstructor]
-		internal BotCache() { }
+		internal BotCache() {
+			SaveTimer = new Timer(
+				async _ => {
+					try {
+						await Save().ConfigureAwait(false);
+					} catch (Exception e) {
+						ASF.ArchiLogger.LogGenericException(e);
+					}
+				},
+				null,
+				Timeout.Infinite,
+				Timeout.Infinite
+			);
+		}
 
 		internal BotCache(string filePath) : this() {
 			if (string.IsNullOrEmpty(filePath)) {
@@ -62,6 +87,17 @@ namespace FreePackages {
 		}
 
 		protected override Task Save() => Save(this);
+
+		private void ScheduleSave() => SaveTimer?.Change(SaveDebounceDelay, Timeout.InfiniteTimeSpan);
+
+		protected override void Dispose(bool disposing) {
+			if (disposing) {
+				SaveTimer?.Dispose();
+				SaveTimer = null;
+			}
+
+			base.Dispose(disposing);
+		}
 
 		internal static async Task<BotCache?> CreateOrLoad(string filePath) {
 			if (string.IsNullOrEmpty(filePath)) {
@@ -107,7 +143,7 @@ namespace FreePackages {
 			}
 
 			Packages.Add(package);
-			Utilities.InBackground(Save);
+			ScheduleSave();
 
 			return true;
 		}
@@ -119,21 +155,21 @@ namespace FreePackages {
 			}
 
 			Packages.UnionWith(packages);
-			Utilities.InBackground(Save);
+			ScheduleSave();
 
 			return true;
 		}
 
 		internal bool RemovePackage(Package package) {
 			Packages.Remove(package);
-			Utilities.InBackground(Save);
+			ScheduleSave();
 
 			return true;
 		}
 
 		internal bool RemoveAppPackages(HashSet<uint> appIDsToRemove) {
 			Packages.Where(x => x.Type == EPackageType.App && appIDsToRemove.Contains(x.ID)).ToList().ForEach(x => Packages.Remove(x));
-			Utilities.InBackground(Save);
+			ScheduleSave();
 
 			return true;
 		}
@@ -168,7 +204,7 @@ namespace FreePackages {
 				}
 			}
 
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal int NumActivationsPastPeriod() {
@@ -204,7 +240,7 @@ namespace FreePackages {
 				NewOwnedPackages.UnionWith(newOwnedPackageIDs);
 			}
 
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void RemoveChange(uint? appID = null, uint? packageID = null, uint? newOwnedPackageID = null) {
@@ -222,25 +258,25 @@ namespace FreePackages {
 		}
 
 		internal void SaveChanges() {
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void ClearQueue() {
 			Packages.RemoveWhere(package => ActivationQueue.ActivationTypes.Contains(package.Type));
 			ChangedApps.Clear();
 			ChangedPackages.Clear();
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void CancelRemoval() {
 			Packages.RemoveWhere(package => RemovalQueue.RemovalTypes.Contains(package.Type));
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void AddWaitlistedPlaytest(uint appID) {
 			WaitlistedPlaytests.Add(appID);
 			
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void UpdateSeenPackages(List<SteamApps.LicenseListCallback.License> newLicenses) {
@@ -248,32 +284,43 @@ namespace FreePackages {
 
 			// Keep track of how many free licenses we activated to enforce the free packages limit
 			// This is to catch packages that were activated, but didn't return a success status, or were activated outside of the plugin
-			/* NOTE: The below code will not capture all recent activations.  If Steam removes a demo from your account, but you add it back, 
+			/* NOTE: The below code will not capture all recent activations.  If Steam removes a demo from your account, but you add it back,
 			 then the package will re-appear with the original TimeCreated value. Activations like these are instead logged when steam reports a
 			 successful activation.
 			 */
-			// TODO: Do other PaymentMethod values also count against the free package limit?
+			// Count clearly-free license types against the free package limit:
+			//   - Complimentary (1024): gifted/free grant from Steam
+			//   - AutoGrant (64): automatically granted (e.g. free-on-demand activations)
+			// Deliberately excluded:
+			//   - GuestPass (8): temporary, does not consume a permanent activation slot
+			//   - ActivationCode (1): redeemed via key, tracked separately
+			//   - Promotional (131): uncertain semantics; left out to avoid over-counting
 			foreach(SteamApps.LicenseListCallback.License license in newLicenses) {
-				if (license.PaymentMethod == EPaymentMethod.Complimentary &&
+				if (CountsAsFreeActivation(license.PaymentMethod) &&
 					license.TimeCreated.ToLocalTime() > DateTime.Now.AddMinutes(-1 * ActivationQueue.ActivationPeriodMinutes)
 				) {
 					AddActivation(license.TimeCreated.ToLocalTime(), packageIDs: [ license.PackageID ]);
 				}
 			}
 
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void IgnoreApp(uint appID) {
 			IgnoredApps.Add(appID);
 
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
 
 		internal void UpdateASFInfoItemCount(uint currentASFInfoItemCount) {
 			LastASFInfoItemCount = currentASFInfoItemCount;
 
-			Utilities.InBackground(Save);
+			ScheduleSave();
 		}
+
+		// Whether a license's PaymentMethod counts as a free activation against the
+		// free-package limit. See UpdateSeenPackages for the rationale of what's included.
+		private static bool CountsAsFreeActivation(EPaymentMethod paymentMethod) =>
+			paymentMethod == EPaymentMethod.Complimentary || paymentMethod == EPaymentMethod.AutoGrant;
 	}
 }

--- a/FreePackages/Data/External/ASFInfo.cs
+++ b/FreePackages/Data/External/ASFInfo.cs
@@ -31,13 +31,14 @@ namespace FreePackages {
 			StreamResponse? response = await ASF.WebBrowser.UrlGetToStream(Source).ConfigureAwait(false);
 
 			if (response == null) {
-				ASF.ArchiLogger.LogNullError(nameof(response));
+				ASF.ArchiLogger.LogGenericError($"ASFinfo update failed: source response was null ({Source})");
 
 				return;
 			}
 
 			if (response.Content == null) {
-				ASF.ArchiLogger.LogNullError(nameof(response.Content));
+				int statusCode = (int) response.StatusCode;
+				ASF.ArchiLogger.LogGenericError($"ASFinfo update failed: source content was null (HTTP {statusCode}, {Source})");
 
 				return;
 			}
@@ -59,14 +60,16 @@ namespace FreePackages {
 
 						if (!match.Success) {
 							ASF.ArchiLogger.LogGenericError(string.Format("{0}: {1}", Strings.ASFInfoParseFailed, line));
-							
-							return;
+
+							// Skip the unparsable line rather than aborting the whole update;
+							// a single bad line (header, comment, blank) must not discard the rest.
+							continue;
 						}
 
 						if (!uint.TryParse(match.Groups["id"].Value, out uint id)) {
 							ASF.ArchiLogger.LogGenericError(string.Format("{0}: {1}", Strings.ASFInfoParseFailed, line));
-							
-							return;
+
+							continue;
 						}
 
 						if (match.Groups["type"].Value == "a") {
@@ -90,6 +93,16 @@ namespace FreePackages {
 
 			foreach (PackageHandler handler in PackageHandler.Handlers.Values) {
 				uint lastCount = handler.BotCache.LastASFInfoItemCount;
+				// If the source list shrank below our last seen position (e.g. the gist
+				// was trimmed), the incremental Skip(lastCount) would skip everything
+				// forever. Reset to 0 and re-scan from the start — re-adding already
+				// seen IDs is safe: duplicates are filtered by owned-checks and RemoveChange.
+				if (lastCount > items.Count) {
+					ASF.ArchiLogger.LogGenericInfo("ASFinfo source shrank; re-scanning from start");
+					lastCount = 0;
+					handler.BotCache.UpdateASFInfoItemCount(0);
+				}
+
 				if (lastCount >= items.Count) {
 					continue;
 				}

--- a/FreePackages/Data/External/PlaytestCatalog.cs
+++ b/FreePackages/Data/External/PlaytestCatalog.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -23,11 +24,45 @@ using ArchiSteamFarm.Web.Responses;
 
 namespace FreePackages {
 	internal static class PlaytestCatalog {
-		private const int PageSize = 50;
-		private const int MaxPages = 200; // 200 * 50 = 10,000 — a safety bound well above the ~2,800 observed
-		private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(15);
+		// Steam's search endpoint caps `count` at 100 per request (verified 2026-07-18:
+		// count=200 returns the same 100 entries as count=100). 100/page is the most we can
+		// get, so a full ~3,005-playtest fetch is 31 pages — and Steam's anonymous-search
+		// burst limit is a HARD ~30-request cap (count-based, not rate-based: spacing
+		// 0s and 1s both die on exactly the 31st request). So the 31st/final page trips the
+		// limit; we ride it out with PageRetryBackoff instead of aborting the whole fetch.
+		private const int PageSize = 100;
+		private const int MaxPages = 200; // 200 * 100 = 20,000 — a safety bound well above the ~3,000 observed
+		// Run the first fetch almost immediately at startup (not after 15 min): until the live
+		// set is populated HasFetched stays false, the gate falls back to PICS-only, and the
+		// persisted queue rains 401 Invalid. A few seconds lets ASF.WebBrowser settle, then we
+		// fetch. Activations are paused for the duration of the fetch so even that window is dry.
+		private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(5);
 		private static readonly TimeSpan RefreshFrequency = TimeSpan.FromMinutes(15);
-		private static readonly TimeSpan EarlyWakeDebounce = TimeSpan.FromSeconds(60);
+		// Early-wake debounce. PICS fires Beta-app changes in bursts, and each wake re-fetches
+		// the WHOLE catalog (all ~31 pages). A 60s debounce turned PICS storms into a full
+		// re-fetch every minute, which both wasted requests and pushed us into Steam's
+		// anonymous-search rate limit. 5 min bounds re-fetches during a storm while still
+		// catching a re-opening well ahead of the 15-min periodic cycle.
+		private static readonly TimeSpan EarlyWakeDebounce = TimeSpan.FromMinutes(5);
+		// Pace the paginated fetch. The burst limit is count-based (~30 requests) so pacing
+		// alone can't avoid it once we exceed 30 pages, but a small delay keeps the request
+		// stream smooth and lets a transient -1 self-recover before we burn a retry slot.
+		private static readonly TimeSpan InterPageDelay = TimeSpan.FromSeconds(1);
+		// Back off and retry the SAME page when Steam rate-limits us (HTTP -1), instead of
+		// aborting the whole fetch at page 30. The cooldown looks like a ~5-min rolling
+		// window, so a few 120s retries give it time to clear and let the final page through.
+		// Worst case (all retries exhausted) we give up, resume activations, and try again
+		// next cycle — the live set stays stale but the queue is never held forever.
+		private const int MaxPageRetries = 4;
+		private static readonly TimeSpan PageRetryBackoff = TimeSpan.FromSeconds(120);
+		// Per-request timeout. A hung Steam GET used to hold RefreshSemaphore forever, which
+		// made every later DoUpdate return silently (no log at all) — indistinguishable from
+		// "the catalog never runs". Bailing after this keeps the timer honest.
+		private static readonly TimeSpan PerRequestTimeout = TimeSpan.FromSeconds(30);
+		// How many pages between progress reports. The fetch is long enough (~60s+) that
+		// reporting collected count + ETA every N pages is useful telemetry, and the reports
+		// also prove the fetch is actually advancing (vs. silently stuck).
+		private const int ProgressReportEvery = 10;
 
 		// data-ds-appid on each search result is the BASE game appID — the same value the
 		// plugin posts to /ajaxrequestplaytestaccess/<id> and stores as app.Parent.ID.
@@ -35,7 +70,12 @@ namespace FreePackages {
 
 		// The URL form verified on 2026-07-17: anonymous, paginated via start=, count=,
 		// category1=989 (Playtests). `infinite=1&json=1` returns {success,total_count,results_html}.
-		private const string SearchUrl = "https://store.steampowered.com/search/results/?query&start={0}&count={1}&dynamic_data=&sort_by=_ASC&snr=1_7_7_230_150&category1=989&infinite=1&json=1";
+		// sort_by MUST be a real deterministic field (Name_ASC). The earlier `sort_by=_ASC`
+		// (empty field) made Steam fall back to a non-deterministic order, so paginating by
+		// `start` returned overlapping slices — a full fetch collected only ~74% of total_count
+		// with unique-per-page declining across the run. Name_ASC partitions cleanly: 100/page,
+		// zero overlap between start=0 and start=100 (verified 2026-07-18).
+		private const string SearchUrl = "https://store.steampowered.com/search/results/?query&start={0}&count={1}&dynamic_data=&sort_by=Name_ASC&snr=1_7_7_230_150&category1=989&infinite=1&json=1";
 
 		private static HashSet<uint> LivePlaytests = new();
 		private static readonly object LiveLock = new();
@@ -46,6 +86,8 @@ namespace FreePackages {
 		private static readonly Timer UpdateTimer = new(async _ => await DoUpdate().ConfigureAwait(false), null, Timeout.Infinite, Timeout.Infinite);
 
 		internal static void Update() {
+			ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog.Update() called — arming timer (first fetch in {InitialDelay.TotalSeconds:F0}s, then every {RefreshFrequency.TotalMinutes:F0}m)");
+
 			UpdateTimer.Change(InitialDelay, RefreshFrequency);
 		}
 
@@ -116,67 +158,135 @@ namespace FreePackages {
 		}
 
 		private static async Task DoUpdate() {
-			ArgumentNullException.ThrowIfNull(ASF.WebBrowser);
-
-			// Skip overlapping invocations (scheduled tick + early wake): the run already
-			// in progress covers the latest state, so a queued second run adds nothing.
-			if (!await RefreshSemaphore.WaitAsync(0).ConfigureAwait(false)) {
-				return;
-			}
-
 			HashSet<uint> fetched = new();
 			int totalCount = 0;
+			int totalPages = 0;
 			bool failed = false;
+			Stopwatch stopwatch = Stopwatch.StartNew();
 
 			try {
-				for (int page = 0; page < MaxPages; page++) {
-					int start = page * PageSize;
+				ArgumentNullException.ThrowIfNull(ASF.WebBrowser);
 
-					if (page > 0 && start >= totalCount) {
-						break;
-					}
+				// Acquire the semaphore exactly ONCE. SemaphoreSlim is non-reentrant: a second
+				// WaitAsync(0) from the same caller while it already holds the slot returns
+				// false. An earlier version of this method had a duplicate acquisition (left over
+				// from wrapping the body in an outer try/catch) — the second WaitAsync(0)
+				// returned false, the method returned here, the inner finally that releases the
+				// semaphore never ran, the slot was leaked, and every later DoUpdate silently
+				// bailed at this same check. Net effect: zero catalog logs, no activation pause,
+				// and the persisted queue drained as the 401 storm we were trying to fix.
+				if (!await RefreshSemaphore.WaitAsync(0).ConfigureAwait(false)) {
+					return;
+				}
 
-					Uri request = new(string.Format(SearchUrl, start, PageSize));
-					ObjectResponse<SearchResults>? response = await ASF.WebBrowser.UrlGetToJsonObject<SearchResults>(request).ConfigureAwait(false);
+				// Hold all activations for the duration of the fetch: the persisted queue is
+				// stale until the live set is refreshed, and claiming from it is the 401 storm.
+				// The log is inside the inner try so the inner finally (Resume) is guaranteed to
+				// run once we've paused, even if the log line itself ever throws.
+				PackageHandler.PauseAllActivations();
 
-					HashSet<uint>? pageAppIDs = ParsePage(response?.Content);
-					if (pageAppIDs == null) {
-						int statusCode = response == null ? -1 : (int) response.StatusCode;
-						ASF.ArchiLogger.LogGenericError($"PlaytestCatalog fetch failed at page {page} (start={start}, HTTP {statusCode})");
+				try {
+					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch beginning — activations paused");
 
-						failed = true;
-						break;
-					}
+					int start = 0;
+					for (int page = 0; page < MaxPages && !failed; page++) {
+						// We know the list length only after the first page; once we do, stop
+						// before walking past it (the last page returns a partial result set).
+						if (page > 0) {
+							if (totalCount > 0 && start >= totalCount) {
+								break;
+							}
 
-					if (page == 0) {
-						totalCount = response!.Content!.TotalCount;
+							await Task.Delay(InterPageDelay).ConfigureAwait(false);
+						}
 
-						if (totalCount <= 0) {
-							ASF.ArchiLogger.LogGenericError("PlaytestCatalog fetch failed: total_count was 0");
+						Uri request = new(string.Format(SearchUrl, start, PageSize));
+						ObjectResponse<SearchResults>? response = null;
+						HashSet<uint>? pageAppIDs = null;
+
+						// Retry the SAME page on a rate-limit/timeout instead of aborting the whole
+						// fetch. The anonymous-search burst cap (~30 requests) means the final
+						// page of a full fetch will be rejected once; backing off lets the rolling
+						// window clear so that page comes through and the fetch completes.
+						for (int attempt = 0; attempt <= MaxPageRetries && pageAppIDs == null; attempt++) {
+							if (attempt > 0) {
+								ASF.ArchiLogger.LogGenericWarning($"PlaytestCatalog rate-limited at page {page} (start={start}); backing off {PageRetryBackoff.TotalSeconds:F0}s (retry {attempt}/{MaxPageRetries})");
+								await Task.Delay(PageRetryBackoff).ConfigureAwait(false);
+							}
+
+							Task<ObjectResponse<SearchResults>?> getTask = ASF.WebBrowser.UrlGetToJsonObject<SearchResults>(request);
+							Task delayTask = Task.Delay(PerRequestTimeout);
+
+							// Don't let a single hung Steam GET hold RefreshSemaphore forever — that
+							// would silently skip every later DoUpdate and produce no logs at all.
+							if (await Task.WhenAny(getTask, delayTask).ConfigureAwait(false) == delayTask) {
+								ASF.ArchiLogger.LogGenericError($"PlaytestCatalog fetch timed out at page {page} (start={start}) after {PerRequestTimeout.TotalSeconds:F0}s");
+
+								continue;
+							}
+
+							response = await getTask.ConfigureAwait(false);
+							pageAppIDs = ParsePage(response?.Content);
+
+							if (pageAppIDs == null) {
+								int statusCode = response == null ? -1 : (int) response.StatusCode;
+								ASF.ArchiLogger.LogGenericWarning($"PlaytestCatalog got HTTP {statusCode} at page {page} (start={start})");
+							}
+						}
+
+						if (pageAppIDs == null) {
+							ASF.ArchiLogger.LogGenericError($"PlaytestCatalog fetch failed at page {page} (start={start}) after {MaxPageRetries + 1} attempt(s) — giving up");
 
 							failed = true;
 							break;
 						}
-					}
 
-					int before = fetched.Count;
-					fetched.UnionWith(pageAppIDs);
+						if (page == 0) {
+							totalCount = response!.Content!.TotalCount;
 
-					// No new entries on a page means we've walked past the end of the list.
-					if (fetched.Count == before) {
-						break;
-					}
+							if (totalCount <= 0) {
+								ASF.ArchiLogger.LogGenericError("PlaytestCatalog fetch failed: total_count was 0");
 
-					if (start + PageSize >= totalCount) {
-						break;
+								failed = true;
+								break;
+							}
+
+							totalPages = (totalCount + PageSize - 1) / PageSize;
+							ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog fetch started: total_count={totalCount} across {totalPages} page(s)");
+						}
+
+						int before = fetched.Count;
+						fetched.UnionWith(pageAppIDs);
+
+						// Advance by the ACTUAL yield, not PageSize: Steam caps count at 100
+						// regardless of what we request, and the last page returns fewer. Walking
+						// by what we actually got means we never skip entries even if count were
+						// silently clamped, and we stop cleanly when a page comes back empty.
+						start += pageAppIDs.Count;
+
+						// No new entries, or an empty page, means we've walked past the end.
+						if (pageAppIDs.Count == 0 || fetched.Count == before) {
+							break;
+						}
+
+						if ((page + 1) % ProgressReportEvery == 0) {
+							double elapsedS = stopwatch.Elapsed.TotalSeconds;
+							double avgPerPage = elapsedS / (page + 1);
+							int remainingPages = Math.Max(0, totalPages - (page + 1));
+							double etaS = remainingPages * avgPerPage;
+
+							ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog fetch progress: page {page + 1}/{totalPages} — {fetched.Count} appID(s) collected, {elapsedS:F0}s elapsed, ~{etaS:F0}s remaining");
+						}
 					}
+				} finally {
+					RefreshSemaphore.Release();
+					PackageHandler.ResumeAllActivations();
+					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch finished — activations resumed");
 				}
 			} catch (Exception e) {
 				ASF.ArchiLogger.LogGenericException(e);
 
 				failed = true;
-			} finally {
-				RefreshSemaphore.Release();
 			}
 
 			// A failed or incomplete fetch keeps the previous live set and MUST NOT prune.
@@ -199,7 +309,7 @@ namespace FreePackages {
 				snapshot = new HashSet<uint>(fetched);
 			}
 
-			ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog fetched {snapshot.Count} live playtest(s) (total_count={totalCount})");
+			ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog fetched {snapshot.Count} live playtest(s) across {totalPages} page(s) in {stopwatch.Elapsed.TotalSeconds:F0}s (total_count={totalCount})");
 
 			// Fan out the prune + proactive enqueue off the timer thread.
 			Utilities.InBackground(() => PackageHandler.OnPlaytestCatalogUpdated(snapshot));

--- a/FreePackages/Data/External/PlaytestCatalog.cs
+++ b/FreePackages/Data/External/PlaytestCatalog.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using ArchiSteamFarm.Core;
+using ArchiSteamFarm.Web.Responses;
+
+// PICS can't tell us whether a playtest's signup is currently open, so more than half
+// of the playtest requests the plugin used to issue came back as 401 ("no playtest for
+// appID") and got re-issued on every PICS change. To stop that storm without a TTL
+// (which would risk missing a playtest that re-opens several times over a weekend),
+// we periodically fetch Steam's own "Playtests" store search (category1=989). That
+// category only ever lists apps whose playtest signup is currently visible, so list
+// membership is the re-trigger: a playtest that leaves the list (dev hid the signup)
+// and later returns (re-opened) is requested again, every time.
+//
+// The live set is the source of truth for "joinable right now". PICS is kept only to
+// (a) resolve playtest_type for the limited/unlimited filter and (b) wake us early via
+// RequestRefresh when a Beta app changes. See the plan in
+// ~/.claude/plans/snappy-weaving-aurora.md for the full rationale.
+
+namespace FreePackages {
+	internal static class PlaytestCatalog {
+		private const int PageSize = 50;
+		private const int MaxPages = 200; // 200 * 50 = 10,000 — a safety bound well above the ~2,800 observed
+		private static readonly TimeSpan InitialDelay = TimeSpan.FromMinutes(15);
+		private static readonly TimeSpan RefreshFrequency = TimeSpan.FromMinutes(15);
+		private static readonly TimeSpan EarlyWakeDebounce = TimeSpan.FromSeconds(60);
+
+		// data-ds-appid on each search result is the BASE game appID — the same value the
+		// plugin posts to /ajaxrequestplaytestaccess/<id> and stores as app.Parent.ID.
+		private static readonly Regex AppIDRegex = new("data-ds-appid=\"(\\d+)\"", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+		// The URL form verified on 2026-07-17: anonymous, paginated via start=, count=,
+		// category1=989 (Playtests). `infinite=1&json=1` returns {success,total_count,results_html}.
+		private const string SearchUrl = "https://store.steampowered.com/search/results/?query&start={0}&count={1}&dynamic_data=&sort_by=_ASC&snr=1_7_7_230_150&category1=989&infinite=1&json=1";
+
+		private static HashSet<uint> LivePlaytests = new();
+		private static readonly object LiveLock = new();
+		internal static bool HasFetched; // True once at least one fetch has replaced the live set
+		private static long LastRefreshRequestTicks; // For the early-wake debounce (DateTime.UtcNow.Ticks)
+
+		private static readonly SemaphoreSlim RefreshSemaphore = new(1, 1);
+		private static readonly Timer UpdateTimer = new(async _ => await DoUpdate().ConfigureAwait(false), null, Timeout.Infinite, Timeout.Infinite);
+
+		internal static void Update() {
+			UpdateTimer.Change(InitialDelay, RefreshFrequency);
+		}
+
+		// Wake the catalog immediately (debounced to ~60s) so a Beta-app PICS change is
+		// reflected within a minute instead of waiting up to 15 minutes for the next cycle.
+		internal static void RequestRefresh() {
+			long now = DateTime.UtcNow.Ticks;
+			long last = Interlocked.Read(ref LastRefreshRequestTicks);
+
+			if (now - last < EarlyWakeDebounce.Ticks) {
+				return;
+			}
+
+			Interlocked.Exchange(ref LastRefreshRequestTicks, now);
+			UpdateTimer.Change(TimeSpan.Zero, RefreshFrequency);
+		}
+
+		internal static bool IsLive(uint baseAppID) {
+			lock (LiveLock) {
+				return LivePlaytests.Contains(baseAppID);
+			}
+		}
+
+		internal static HashSet<uint> GetLiveSet() {
+			lock (LiveLock) {
+				return new HashSet<uint>(LivePlaytests);
+			}
+		}
+
+		// Parse the BASE appIDs out of one page of results_html. Exposed for unit tests
+		// (the fetch itself hits the network and is not covered there). Returns null
+		// when the page is unusable so the caller can abort the whole fetch cleanly.
+		internal static HashSet<uint>? ParsePage(SearchResults? page) {
+			if (page == null || page.Success != 1) {
+				return null;
+			}
+
+			return ParseAppIDs(page.ResultsHtml);
+		}
+
+		internal static HashSet<uint> ParseAppIDs(string resultsHtml) {
+			HashSet<uint> appIDs = new();
+
+			foreach (Match match in AppIDRegex.Matches(resultsHtml)) {
+				if (uint.TryParse(match.Groups[1].Value, out uint appID) && appID > 0) {
+					appIDs.Add(appID);
+				}
+			}
+
+			return appIDs;
+		}
+
+		// A fetch is only "complete" (and therefore safe to prune from) when we actually
+		// parsed a set close to what Steam reports. Parsing far fewer entries than
+		// total_count usually means the store markup changed and we scraped nothing — in
+		// that case we must NOT replace the live set or prune, otherwise a markup change
+		// would wipe RequestedPlaytests and re-request the entire catalog.
+		internal static bool IsFetchComplete(HashSet<uint> fetched, int totalCount) {
+			if (fetched.Count == 0 || totalCount <= 0) {
+				return false;
+			}
+
+			if (fetched.Count < totalCount / 2) {
+				return false;
+			}
+
+			return true;
+		}
+
+		private static async Task DoUpdate() {
+			ArgumentNullException.ThrowIfNull(ASF.WebBrowser);
+
+			// Skip overlapping invocations (scheduled tick + early wake): the run already
+			// in progress covers the latest state, so a queued second run adds nothing.
+			if (!await RefreshSemaphore.WaitAsync(0).ConfigureAwait(false)) {
+				return;
+			}
+
+			HashSet<uint> fetched = new();
+			int totalCount = 0;
+			bool failed = false;
+
+			try {
+				for (int page = 0; page < MaxPages; page++) {
+					int start = page * PageSize;
+
+					if (page > 0 && start >= totalCount) {
+						break;
+					}
+
+					Uri request = new(string.Format(SearchUrl, start, PageSize));
+					ObjectResponse<SearchResults>? response = await ASF.WebBrowser.UrlGetToJsonObject<SearchResults>(request).ConfigureAwait(false);
+
+					HashSet<uint>? pageAppIDs = ParsePage(response?.Content);
+					if (pageAppIDs == null) {
+						int statusCode = response == null ? -1 : (int) response.StatusCode;
+						ASF.ArchiLogger.LogGenericError($"PlaytestCatalog fetch failed at page {page} (start={start}, HTTP {statusCode})");
+
+						failed = true;
+						break;
+					}
+
+					if (page == 0) {
+						totalCount = response!.Content!.TotalCount;
+
+						if (totalCount <= 0) {
+							ASF.ArchiLogger.LogGenericError("PlaytestCatalog fetch failed: total_count was 0");
+
+							failed = true;
+							break;
+						}
+					}
+
+					int before = fetched.Count;
+					fetched.UnionWith(pageAppIDs);
+
+					// No new entries on a page means we've walked past the end of the list.
+					if (fetched.Count == before) {
+						break;
+					}
+
+					if (start + PageSize >= totalCount) {
+						break;
+					}
+				}
+			} catch (Exception e) {
+				ASF.ArchiLogger.LogGenericException(e);
+
+				failed = true;
+			} finally {
+				RefreshSemaphore.Release();
+			}
+
+			// A failed or incomplete fetch keeps the previous live set and MUST NOT prune.
+			// See IsFetchComplete for the markup-change safety net.
+			if (failed || !IsFetchComplete(fetched, totalCount)) {
+				int previousCount;
+				lock (LiveLock) {
+					previousCount = LivePlaytests.Count;
+				}
+
+				ASF.ArchiLogger.LogGenericError($"PlaytestCatalog refresh did not complete cleanly (failed={failed}, fetched={fetched.Count}, total_count={totalCount}); keeping previous live set of {previousCount} playtest(s)");
+
+				return;
+			}
+
+			HashSet<uint> snapshot;
+			lock (LiveLock) {
+				LivePlaytests = fetched;
+				HasFetched = true;
+				snapshot = new HashSet<uint>(fetched);
+			}
+
+			ASF.ArchiLogger.LogGenericInfo($"PlaytestCatalog fetched {snapshot.Count} live playtest(s) (total_count={totalCount})");
+
+			// Fan out the prune + proactive enqueue off the timer thread.
+			Utilities.InBackground(() => PackageHandler.OnPlaytestCatalogUpdated(snapshot));
+		}
+
+		// Mirrors the Json.cs pattern: private init + JsonConstructor so ASF's source-gen
+		// serializer populates these from the anonymous search response.
+		internal sealed class SearchResults {
+			[JsonInclude]
+			[JsonPropertyName("success")]
+			[JsonRequired]
+			internal int Success { get; private init; } = 0;
+
+			[JsonInclude]
+			[JsonPropertyName("total_count")]
+			[JsonRequired]
+			internal int TotalCount { get; private init; } = 0;
+
+			[JsonInclude]
+			[JsonPropertyName("results_html")]
+			[JsonRequired]
+			internal string ResultsHtml { get; private init; } = "";
+
+			[JsonConstructor]
+			internal SearchResults() { }
+
+			// For unit tests: the private init setters are only reachable from within the
+			// type, so tests build instances through this constructor instead of an
+			// object initializer. The serializer uses the parameterless one above.
+			internal SearchResults(int success, int totalCount, string resultsHtml) {
+				Success = success;
+				TotalCount = totalCount;
+				ResultsHtml = resultsHtml;
+			}
+		}
+	}
+}

--- a/FreePackages/Data/External/PlaytestCatalog.cs
+++ b/FreePackages/Data/External/PlaytestCatalog.cs
@@ -32,22 +32,35 @@ namespace FreePackages {
 		// limit; we ride it out with PageRetryBackoff instead of aborting the whole fetch.
 		private const int PageSize = 100;
 		private const int MaxPages = 200; // 200 * 100 = 20,000 — a safety bound well above the ~3,000 observed
-		// Run the first fetch almost immediately at startup (not after 15 min): until the live
-		// set is populated HasFetched stays false, the gate falls back to PICS-only, and the
-		// persisted queue rains 401 Invalid. A few seconds lets ASF.WebBrowser settle, then we
-		// fetch. Activations are paused for the duration of the fetch so even that window is dry.
+		// Run the first fetch almost immediately at startup (not after the full interval): until
+		// the live set is populated HasFetched stays false, the gate falls back to PICS-only, and
+		// the persisted queue rains 401 Invalid. A few seconds lets ASF.WebBrowser settle, then
+		// we fetch. PLAYTEST activations are paused for the duration of the fetch so even that
+		// window is dry; apps/subs keep going.
 		private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(5);
-		private static readonly TimeSpan RefreshFrequency = TimeSpan.FromMinutes(15);
+		// Fetch the catalog once per hour. Each fetch is ~31 paginated GETs, and a playtest can
+		// only re-open a handful of times over a weekend, so an hourly cadence keeps our request
+		// volume low for a negligible increase in the chance we miss a briefly-open window.
+		private static readonly TimeSpan RefreshFrequency = TimeSpan.FromMinutes(60);
 		// Early-wake debounce. PICS fires Beta-app changes in bursts, and each wake re-fetches
-		// the WHOLE catalog (all ~31 pages). A 60s debounce turned PICS storms into a full
-		// re-fetch every minute, which both wasted requests and pushed us into Steam's
-		// anonymous-search rate limit. 5 min bounds re-fetches during a storm while still
-		// catching a re-opening well ahead of the 15-min periodic cycle.
-		private static readonly TimeSpan EarlyWakeDebounce = TimeSpan.FromMinutes(5);
-		// Pace the paginated fetch. The burst limit is count-based (~30 requests) so pacing
-		// alone can't avoid it once we exceed 30 pages, but a small delay keeps the request
-		// stream smooth and lets a transient -1 self-recover before we burn a retry slot.
-		private static readonly TimeSpan InterPageDelay = TimeSpan.FromSeconds(1);
+		// the WHOLE catalog (all ~31 pages). Bounding this to the same hourly cadence keeps PICS
+		// storms from turning into a re-fetch every few minutes, which both wasted requests and
+		// pushed us into Steam's anonymous-search rate limit. A re-opening is still caught within
+		// an hour — the same window the periodic cycle already targets.
+		private static readonly TimeSpan EarlyWakeDebounce = TimeSpan.FromMinutes(60);
+		// Pace the paginated fetch. Steam's anonymous-search burst limit is a HARD ~30-request
+		// cap inside a ~5-minute (300s) SLIDING window (count-based, not rate-based: spacing 0s
+		// and 1s both die on exactly the 31st request). The window slides, so what matters is
+		// request DENSITY inside any 300s span, not the total fetch duration: "spread the fetch
+		// past 5 minutes" does NOT help on its own, since a sliding window still catches every
+		// request that lands within 300s of another.
+		//
+		// At S seconds spacing, any 300s sliding window holds at most floor(300/S)+1 requests,
+		// so S=25 => ~12 requests/window = 40% of the 30-cap, leaving headroom for other
+		// anonymous store-search calls. A full 31-page fetch then takes 31 * 25s ~ 13 min, well
+		// inside the hourly cadence (RefreshFrequency below). The backoff stays as a safety net
+		// in case the real window is longer than observed.
+		private static readonly TimeSpan InterPageDelay = TimeSpan.FromSeconds(25);
 		// Back off and retry the SAME page when Steam rate-limits us (HTTP -1), instead of
 		// aborting the whole fetch at page 30. The cooldown looks like a ~5-min rolling
 		// window, so a few 120s retries give it time to clear and let the final page through.
@@ -91,8 +104,9 @@ namespace FreePackages {
 			UpdateTimer.Change(InitialDelay, RefreshFrequency);
 		}
 
-		// Wake the catalog immediately (debounced to ~60s) so a Beta-app PICS change is
-		// reflected within a minute instead of waiting up to 15 minutes for the next cycle.
+		// Wake the catalog immediately (debounced to the hourly cadence) so a Beta-app PICS
+		// change can be reflected sooner than the next periodic cycle instead of waiting up
+		// to an hour. The debounce keeps PICS storms from re-fetching every few minutes.
 		internal static void RequestRefresh() {
 			long now = DateTime.UtcNow.Ticks;
 			long last = Interlocked.Read(ref LastRefreshRequestTicks);
@@ -179,14 +193,15 @@ namespace FreePackages {
 					return;
 				}
 
-				// Hold all activations for the duration of the fetch: the persisted queue is
-				// stale until the live set is refreshed, and claiming from it is the 401 storm.
-				// The log is inside the inner try so the inner finally (Resume) is guaranteed to
-				// run once we've paused, even if the log line itself ever throws.
-				PackageHandler.PauseAllActivations();
+				// Hold PLAYTEST activations for the duration of the fetch: the persisted playtest
+				// queue is stale until the live set is refreshed, and claiming from it is the 401
+				// storm. Apps/subs keep activating normally. The log is inside the inner try so the
+				// inner finally (Resume) is guaranteed to run once we've paused, even if the log
+				// line itself ever throws.
+				PackageHandler.PausePlaytestActivations();
 
 				try {
-					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch beginning — activations paused");
+					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch beginning — playtest activations paused");
 
 					int start = 0;
 					for (int page = 0; page < MaxPages && !failed; page++) {
@@ -280,8 +295,8 @@ namespace FreePackages {
 					}
 				} finally {
 					RefreshSemaphore.Release();
-					PackageHandler.ResumeAllActivations();
-					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch finished — activations resumed");
+					PackageHandler.ResumePlaytestActivations();
+					ASF.ArchiLogger.LogGenericInfo("PlaytestCatalog fetch finished — playtest activations resumed");
 				}
 			} catch (Exception e) {
 				ASF.ArchiLogger.LogGenericException(e);

--- a/FreePackages/Data/PICS/ProductInfo.cs
+++ b/FreePackages/Data/PICS/ProductInfo.cs
@@ -55,18 +55,26 @@ namespace FreePackages {
 		private async static Task<List<SteamApps.PICSProductInfoCallback>?> FetchProductInfo(IEnumerable<uint>? appIDs = null, IEnumerable<uint>? packageIDs = null) {
 			await ProductInfoSemaphore.WaitAsync().ConfigureAwait(false);
 			try {
-				Bot? bot = Bot.BotsReadOnly?.Values.FirstOrDefault(static bot => bot.IsConnectedAndLoggedOn);
-				if (bot == null) {
-					return null;
-				}
-
 				var apps = appIDs == null ? Enumerable.Empty<SteamApps.PICSRequest>() : appIDs.Select(x => new SteamApps.PICSRequest(x));
 				var packages = packageIDs == null ? Enumerable.Empty<SteamApps.PICSRequest>() : packageIDs.Select(x => new SteamApps.PICSRequest(x, ASF.GlobalDatabase?.PackageAccessTokensReadOnly.GetValueOrDefault(x, (ulong) 0) ?? 0));
-				var response = await bot.SteamApps.PICSGetProductInfo(apps, packages).ToLongRunningTask().ConfigureAwait(false);
 
-				return response.Results?.ToList();
-			} catch (Exception e) {
-				ASF.ArchiLogger.LogGenericWarningException(e);
+				// Try each connected bot in turn: a single failing/disconnecting bot must not
+				// discard the whole batch. The rate-limiting delay still applies once per pass.
+				foreach (Bot bot in Bot.BotsReadOnly?.Values.Where(static bot => bot.IsConnectedAndLoggedOn).ToList() ?? new List<Bot>()) {
+					try {
+						var response = await bot.SteamApps.PICSGetProductInfo(apps, packages).ToLongRunningTask().ConfigureAwait(false);
+
+						var results = response.Results?.ToList();
+
+						if (results != null) {
+							return results;
+						}
+					} catch (Exception e) {
+						ASF.ArchiLogger.LogGenericWarningException(e);
+
+						// Fall through to the next connected bot
+					}
+				}
 
 				return null;
 			} finally {

--- a/FreePackages/FreePackages.cs
+++ b/FreePackages/FreePackages.cs
@@ -34,6 +34,7 @@ namespace FreePackages {
 
 			CardApps.Update();
 			ASFInfo.Update();
+			PlaytestCatalog.Update();
 		}
 
 		public async Task OnBotInitModules(Bot bot, IReadOnlyDictionary<string, JsonElement>? additionalConfigProperties = null) {

--- a/FreePackages/FreePackages.cs
+++ b/FreePackages/FreePackages.cs
@@ -131,7 +131,9 @@ namespace FreePackages {
 		}
 
 		public Task OnBotDisconnected(Bot bot, EResult reason) {
-			return Task.FromResult(0);
+			PackageHandler.OnBotDisconnected(bot);
+
+			return Task.CompletedTask;
 		}
 	}
 }

--- a/FreePackages/Handlers/PICSHandler.cs
+++ b/FreePackages/Handlers/PICSHandler.cs
@@ -112,14 +112,21 @@ namespace FreePackages {
 		private async static Task<SteamApps.PICSChangesCallback?> FetchPICSChanges(uint changeNumber, bool sendAppChangeList = true, bool sendPackageChangeList = true) {
 			await PICSChangesSemaphore.WaitAsync().ConfigureAwait(false);
 			try {
-				Bot? refreshBot = GetRefreshBot();
-				if (refreshBot == null) {
-					return null;
-				}
+				// Try each connected bot in turn: a single failing/disconnecting bot must not
+				// discard the whole batch. The rate-limiting delay still applies once per pass.
+				foreach (Bot refreshBot in GetRefreshBots()) {
+					try {
+						SteamApps.PICSChangesCallback? result = await refreshBot.SteamApps.PICSGetChangesSince(changeNumber, sendAppChangeList, sendPackageChangeList).ToLongRunningTask().ConfigureAwait(false);
 
-				return await refreshBot.SteamApps.PICSGetChangesSince(changeNumber, sendAppChangeList, sendPackageChangeList).ToLongRunningTask().ConfigureAwait(false);
-			} catch (Exception e) {
-				ASF.ArchiLogger.LogGenericWarningException(e);
+						if (result != null) {
+							return result;
+						}
+					} catch (Exception e) {
+						ASF.ArchiLogger.LogGenericWarningException(e);
+
+						// Fall through to the next connected bot
+					}
+				}
 
 				return null;
 			} finally {
@@ -132,6 +139,6 @@ namespace FreePackages {
 			}
 		}
 
-		private static Bot? GetRefreshBot() => Bot.BotsReadOnly?.Values.FirstOrDefault(static bot => bot.IsConnectedAndLoggedOn);
+		private static List<Bot> GetRefreshBots() => Bot.BotsReadOnly?.Values.Where(static bot => bot.IsConnectedAndLoggedOn).ToList() ?? new List<Bot>();
 	}
 }

--- a/FreePackages/Handlers/PackageHandler.cs
+++ b/FreePackages/Handlers/PackageHandler.cs
@@ -21,6 +21,12 @@ namespace FreePackages {
 		ConcurrentHashSet<Package> PackagesToRemove = new(new PackageComparer());
 		internal static ConcurrentDictionary<string, PackageHandler> Handlers = new();
 
+	// Set by PlaytestCatalog.DoUpdate for the duration of a fetch so every bot's
+	// ActivationQueue holds off claiming — the persisted queue is stale until the live set
+	// is refreshed, and claiming from it produces the 401 Invalid storm we're fixing.
+	// Volatile: written on the catalog timer thread, read on each queue's timer thread.
+	internal static volatile bool ActivationsPausedGlobally;
+
 		private readonly Timer UserDataRefreshTimer;
 		private static SemaphoreSlim AddHandlerSemaphore = new SemaphoreSlim(1, 1);
 		private static SemaphoreSlim ProcessChangesSemaphore = new SemaphoreSlim(1, 1);
@@ -100,6 +106,22 @@ namespace FreePackages {
 			handler.RemovalCancellation?.Cancel();
 		}
 
+		// Bracket a PlaytestCatalog fetch: while the flag is set, every ActivationQueue holds
+		// (see ActivationQueue.IsPaused) so the stale persisted queue doesn't fire 401s before
+		// the live set is refreshed. Resume nudges each queue so it re-checks immediately.
+		// Removals are intentionally NOT paused — they're unrelated to the playtest storm.
+		internal static void PauseAllActivations() {
+			ActivationsPausedGlobally = true;
+		}
+
+		internal static void ResumeAllActivations() {
+			ActivationsPausedGlobally = false;
+
+			foreach (PackageHandler handler in Handlers.Values) {
+				handler.ActivationQueue.Nudge();
+			}
+		}
+
 		// Called by PlaytestCatalog after every successful, complete fetch. Prunes the
 		// suppression sets of every connected, ready bot against the new live set, then
 		// proactively enqueues any live playtest the bot hasn't already requested or
@@ -127,6 +149,11 @@ namespace FreePackages {
 				}
 
 				handler.BotCache.PrunePlaytests(liveSet);
+
+				// Drop now-closed playtests from the activation queue too, so the stale
+				// persisted entries (from before the gate existed, or from the PICS path) don't
+				// drain one-by-one as 401 Invalid. Live playtests stay queued and are claimed.
+				handler.BotCache.PrunePlaytestPackages(liveSet);
 
 				bool wantsPlaytests = handler.PackageFilter.FilterConfigs.Any(static filter => filter.PlaytestMode != EPlaytestMode.None);
 				if (!wantsPlaytests) {

--- a/FreePackages/Handlers/PackageHandler.cs
+++ b/FreePackages/Handlers/PackageHandler.cs
@@ -37,6 +37,7 @@ namespace FreePackages {
 		public void Dispose() {
 			ActivationQueue.Dispose();
 			UserDataRefreshTimer.Dispose();
+			BotCache.Dispose();
 		}
 
 		internal static async Task AddHandler(Bot bot, List<FilterConfig> filterConfigs, uint? packageLimit, bool pauseWhilePlaying, bool pauseWhileFarming) {
@@ -87,6 +88,18 @@ namespace FreePackages {
 			Handlers[bot.BotName].RemovalQueue.Start();
 		}
 
+		internal static void OnBotDisconnected(Bot bot) {
+			if (!Handlers.TryGetValue(bot.BotName, out PackageHandler? handler)) {
+				return;
+			}
+
+			// Cancel any in-flight ScanRemovables for this bot so a disconnect doesn't
+			// leave it blocked on ProcessChangesSemaphore / product info fetches. The
+			// activation/removal queues self-pause via Bot.IsConnectedAndLoggedOn and
+			// resume on their own timers on reconnect — no need to touch them here.
+			handler.RemovalCancellation?.Cancel();
+		}
+
 		private void UpdateUserData() {
 			UserDataRefreshTimer.Change(TimeSpan.Zero, TimeSpan.FromMinutes(15));
 		}
@@ -134,12 +147,25 @@ namespace FreePackages {
 			Utilities.InBackground(async() => await HandleChanges().ConfigureAwait(false));
 		}
 
-		private async static Task<bool> IsReady(uint maxWaitTimeSeconds = 120) {
+		// Waits for every enabled bot's PackageFilter to be ready before processing a
+		// changelist. The return value is intentionally ignored by HandleChanges: a
+		// non-ready bot early-returns inside HandleFreeApp/HandleFreePackage (before its
+		// RemoveChange finally block), so its changes stay in ChangedApps/ChangedPackages
+		// and are retried on the next cycle. We therefore cap the wait at a short bound
+		// (default 15 s) rather than blocking the whole batch for one stuck bot, and log
+		// when we give up so the operator can see which bot is lagging.
+		private async static Task<bool> IsReady(uint maxWaitTimeSeconds = 15) {
 			DateTime timeoutTime = DateTime.Now.AddSeconds(maxWaitTimeSeconds);
 			do {
-				bool ready = Handlers.Values.Where(x => x.Bot.BotConfig.Enabled && !x.PackageFilter.Ready).Count() == 0;
-				if (ready) {
+				IReadOnlyCollection<PackageHandler> notReady = Handlers.Values.Where(x => x.Bot.BotConfig.Enabled && !x.PackageFilter.Ready).ToList();
+				if (notReady.Count == 0) {
 					return true;
+				}
+
+				if (maxWaitTimeSeconds > 0 && DateTime.Now >= timeoutTime) {
+					ASF.ArchiLogger.LogGenericWarning($"IsReady timed out after {maxWaitTimeSeconds}s; {notReady.Count}/{Handlers.Values.Count(x => x.Bot.BotConfig.Enabled)} bot(s) not ready: {String.Join(", ", notReady.Select(x => x.Bot.BotName))}. Proceeding anyway — their changes will be retried.");
+
+					return false;
 				}
 
 				await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
@@ -190,7 +216,7 @@ namespace FreePackages {
 				).ConfigureAwait(false);
 
 				if (apps == null) {
-					ASF.ArchiLogger.LogGenericError(Strings.ProductInfoFetchFailed);
+					ASF.ArchiLogger.LogGenericError($"{Strings.ProductInfoFetchFailed} (while extracting apps from {productInfos.Count} product info callback(s))");
 
 					return;
 				}
@@ -218,7 +244,7 @@ namespace FreePackages {
 				).ConfigureAwait(false);
 
 				if (packages == null) {
-					ASF.ArchiLogger.LogGenericError(Strings.ProductInfoFetchFailed);
+					ASF.ArchiLogger.LogGenericError($"{Strings.ProductInfoFetchFailed} (while extracting packages from {productInfos.Count} product info callback(s))");
 
 					return;
 				}

--- a/FreePackages/Handlers/PackageHandler.cs
+++ b/FreePackages/Handlers/PackageHandler.cs
@@ -100,6 +100,50 @@ namespace FreePackages {
 			handler.RemovalCancellation?.Cancel();
 		}
 
+		// Called by PlaytestCatalog after every successful, complete fetch. Prunes the
+		// suppression sets of every connected, ready bot against the new live set, then
+		// proactively enqueues any live playtest the bot hasn't already requested or
+		// waitlisted. This catches playtests PICS never surfaced (the original discovery
+		// gap) without re-requesting ones already handled this epoch.
+		//
+		// The proactive path intentionally does NOT apply the limited/unlimited
+		// PlaytestMode filter: the catalog only gives us BASE appIDs, and resolving each
+		// one's playtest_type would cost an extra PICS fetch per playtest. The PICS path
+		// (HandlePlaytest) still applies that filter for playtests it discovers. Missing
+		// a re-opening is worse than occasionally enqueuing a limited playtest a
+		// unlimited-only bot didn't strictly want.
+		internal static void OnPlaytestCatalogUpdated(HashSet<uint> liveSet) {
+			ArgumentNullException.ThrowIfNull(liveSet);
+
+			if (liveSet.Count == 0 || Handlers.Count == 0) {
+				return;
+			}
+
+			foreach (PackageHandler handler in Handlers.Values) {
+				if (!handler.Bot.IsConnectedAndLoggedOn || !handler.PackageFilter.Ready) {
+					// Offline / not-yet-ready bots are skipped; they'll be caught on the next
+					// cycle once they're connected and their filter is populated.
+					continue;
+				}
+
+				handler.BotCache.PrunePlaytests(liveSet);
+
+				bool wantsPlaytests = handler.PackageFilter.FilterConfigs.Any(static filter => filter.PlaytestMode != EPlaytestMode.None);
+				if (!wantsPlaytests) {
+					continue;
+				}
+
+				int filterHash = handler.PackageFilter.Hash;
+				foreach (uint baseAppID in liveSet) {
+					if (handler.BotCache.RequestedPlaytests.Contains(baseAppID) || handler.BotCache.WaitlistedPlaytests.Contains(baseAppID)) {
+						continue;
+					}
+
+					handler.BotCache.AddPackage(new Package(EPackageType.Playtest, baseAppID, filterHash: filterHash));
+				}
+			}
+		}
+
 		private void UpdateUserData() {
 			UserDataRefreshTimer.Change(TimeSpan.Zero, TimeSpan.FromMinutes(15));
 		}
@@ -225,6 +269,9 @@ namespace FreePackages {
 					apps.ForEach(app => {
 						if (app.Type == EAppType.Beta) {
 							Handlers.Values.ToList().ForEach(x => x.HandlePlaytest(app));
+							// A Beta-app change may be the first sign a playtest just opened; wake the
+							// catalog (debounced) so the live set reflects it within a minute.
+							PlaytestCatalog.RequestRefresh();
 						} else {
 							Handlers.Values.ToList().ForEach(x => x.HandleFreeApp(app));
 						}
@@ -339,6 +386,15 @@ namespace FreePackages {
 
 			try {
 				if (app.Parent == null) {
+					return;
+				}
+
+				// Once the catalog has fetched at least once, gate strictly on the live
+				// set: a Beta-app PICS change for a playtest whose signup isn't currently
+				// open must not produce a POST. Before the first successful fetch the live
+				// set is empty, so we fall back to the original PICS-only behaviour rather
+				// than killing every playtest on a fresh start.
+				if (PlaytestCatalog.HasFetched && !PlaytestCatalog.IsLive(app.Parent.ID)) {
 					return;
 				}
 

--- a/FreePackages/Handlers/PackageHandler.cs
+++ b/FreePackages/Handlers/PackageHandler.cs
@@ -22,10 +22,11 @@ namespace FreePackages {
 		internal static ConcurrentDictionary<string, PackageHandler> Handlers = new();
 
 	// Set by PlaytestCatalog.DoUpdate for the duration of a fetch so every bot's
-	// ActivationQueue holds off claiming — the persisted queue is stale until the live set
-	// is refreshed, and claiming from it produces the 401 Invalid storm we're fixing.
-	// Volatile: written on the catalog timer thread, read on each queue's timer thread.
-	internal static volatile bool ActivationsPausedGlobally;
+	// ActivationQueue skips PLAYTEST claims only (apps/subs keep going) — the persisted
+	// playtest queue is stale until the live set is refreshed, and claiming from it
+	// produces the 401 Invalid storm we're fixing. Volatile: written on the catalog
+	// timer thread, read on each queue's timer thread.
+	internal static volatile bool PlaytestsPausedGlobally;
 
 		private readonly Timer UserDataRefreshTimer;
 		private static SemaphoreSlim AddHandlerSemaphore = new SemaphoreSlim(1, 1);
@@ -106,16 +107,17 @@ namespace FreePackages {
 			handler.RemovalCancellation?.Cancel();
 		}
 
-		// Bracket a PlaytestCatalog fetch: while the flag is set, every ActivationQueue holds
-		// (see ActivationQueue.IsPaused) so the stale persisted queue doesn't fire 401s before
-		// the live set is refreshed. Resume nudges each queue so it re-checks immediately.
-		// Removals are intentionally NOT paused — they're unrelated to the playtest storm.
-		internal static void PauseAllActivations() {
-			ActivationsPausedGlobally = true;
+		// Bracket a PlaytestCatalog fetch: while the flag is set, every ActivationQueue skips
+		// PLAYTEST packages only (see ActivationQueue.GetNextPackage) so the stale persisted
+		// playtest queue doesn't fire 401s before the live set is refreshed — apps/subs keep
+		// activating normally. Resume nudges each queue so it re-checks immediately.
+		// Removals are never paused — they're unrelated to the playtest storm.
+		internal static void PausePlaytestActivations() {
+			PlaytestsPausedGlobally = true;
 		}
 
-		internal static void ResumeAllActivations() {
-			ActivationsPausedGlobally = false;
+		internal static void ResumePlaytestActivations() {
+			PlaytestsPausedGlobally = false;
 
 			foreach (PackageHandler handler in Handlers.Values) {
 				handler.ActivationQueue.Nudge();

--- a/FreePackages/Handlers/PackageHandler.cs
+++ b/FreePackages/Handlers/PackageHandler.cs
@@ -125,17 +125,23 @@ namespace FreePackages {
 		}
 
 		// Called by PlaytestCatalog after every successful, complete fetch. Prunes the
-		// suppression sets of every connected, ready bot against the new live set, then
-		// proactively enqueues any live playtest the bot hasn't already requested or
-		// waitlisted. This catches playtests PICS never surfaced (the original discovery
-		// gap) without re-requesting ones already handled this epoch.
+		// suppression sets and stale playtest packages of every connected, ready bot
+		// against the new live set, then proactively enqueues live playtests for bots
+		// whose filter accepts every playtest. This catches playtests PICS never
+		// surfaced (the original discovery gap) without re-requesting ones already
+		// handled this epoch, and without bypassing the user's filters.
 		//
-		// The proactive path intentionally does NOT apply the limited/unlimited
-		// PlaytestMode filter: the catalog only gives us BASE appIDs, and resolving each
-		// one's playtest_type would cost an extra PICS fetch per playtest. The PICS path
-		// (HandlePlaytest) still applies that filter for playtests it discovers. Missing
-		// a re-opening is worse than occasionally enqueuing a limited playtest a
-		// unlimited-only bot didn't strictly want.
+		// The proactive path runs only for a bot that has an "unconstrained all
+		// playtests" filter (PackageFilter.IsUnconstrainedAllPlaytestsFilter: PlaytestMode
+		// is All and no other app-level constraint is set). The catalog carries only BASE
+		// appIDs — no playtest_type, tags, review score, languages, etc. — so the
+		// proactive path can't honor limited/unlimited or any other filter; it is only
+		// safe to enqueue every live playtest when the filter would accept any playtest
+		// regardless. Bots with any finer filter (limited-only, a tag, an ignored app, a
+		// review floor, wishlist-only, an age cap, ...) are left to the PICS path
+		// (HandlePlaytest), which resolves the full app metadata and applies the filter
+		// before enqueueing. Pruning still runs for every bot so a playtest that re-opens
+		// later is re-requestable.
 		internal static void OnPlaytestCatalogUpdated(HashSet<uint> liveSet) {
 			ArgumentNullException.ThrowIfNull(liveSet);
 
@@ -157,8 +163,11 @@ namespace FreePackages {
 				// drain one-by-one as 401 Invalid. Live playtests stay queued and are claimed.
 				handler.BotCache.PrunePlaytestPackages(liveSet);
 
-				bool wantsPlaytests = handler.PackageFilter.FilterConfigs.Any(static filter => filter.PlaytestMode != EPlaytestMode.None);
-				if (!wantsPlaytests) {
+				// Only a bot whose filter accepts every playtest can be driven proactively
+				// from the catalog; the catalog carries no metadata to honor any finer filter,
+				// so a bot with a constrained filter is left to the PICS path instead.
+				bool allowProactive = handler.PackageFilter.FilterConfigs.Any(PackageFilter.IsUnconstrainedAllPlaytestsFilter);
+				if (!allowProactive) {
 					continue;
 				}
 

--- a/FreePackages/PackageFilter/PackageFilter.cs
+++ b/FreePackages/PackageFilter/PackageFilter.cs
@@ -326,6 +326,96 @@ namespace FreePackages {
 			return true;
 		}
 
+		// True when <paramref name="filter"/> accepts every playtest with no constraint
+		// beyond "is a playtest": PlaytestMode is All (both limited and unlimited) and no
+		// app-level field that could reject a playtest is set. The proactive catalog path
+		// (PackageHandler.OnPlaytestCatalogUpdated) enqueues every live playtest from a
+		// fetch that carries only BASE appIDs — no playtest_type, tags, review score,
+		// languages, etc. — so it can only be correct when the filter would accept any
+		// playtest regardless. Any finer filter (limited-only, a tag, an ignored app, a
+		// review floor, wishlist-only, an age cap, ...) falls back to the PICS path
+		// (HandlePlaytest), which resolves the full app metadata and applies the filter
+		// before enqueueing. Errs toward "constrained": a field that is set but happens to
+		// be irrelevant to playtests (e.g. MinReviewScore, which IsAppWantedByFilter skips
+		// for Beta apps) still suppresses proactive, rather than risk bypassing a future
+		// constraint. IgnoredTypes defaults to {"Demo"}, which never rejects a playtest, so
+		// the default is allowed; any other ignored type is treated as a constraint.
+		internal static bool IsUnconstrainedAllPlaytestsFilter(FilterConfig filter) {
+			ArgumentNullException.ThrowIfNull(filter);
+
+			if (filter.PlaytestMode != EPlaytestMode.All) {
+				return false;
+			}
+
+			if (filter.ImportStoreFilters) {
+				return false;
+			}
+
+			if (filter.Types.Count > 0) {
+				return false;
+			}
+
+			if (filter.Categories.Count > 0) {
+				return false;
+			}
+
+			if (filter.Tags.Count > 0) {
+				return false;
+			}
+
+			if (filter.IgnoredAppIDs.Count > 0) {
+				return false;
+			}
+
+			if (filter.IgnoredTags.Count > 0) {
+				return false;
+			}
+
+			if (filter.IgnoredCategories.Count > 0) {
+				return false;
+			}
+
+			if (filter.IgnoredContentDescriptors.Count > 0) {
+				return false;
+			}
+
+			if (filter.IgnoreFreeWeekends) {
+				return false;
+			}
+
+			if (filter.MinReviewScore > 0) {
+				return false;
+			}
+
+			if (filter.Languages.Count > 0) {
+				return false;
+			}
+
+			if (filter.NoCostOnly) {
+				return false;
+			}
+
+			if (filter.Systems.Count > 0) {
+				return false;
+			}
+
+			if (filter.WishlistOnly) {
+				return false;
+			}
+
+			if (filter.MaxDaysOld > 0) {
+				return false;
+			}
+
+			foreach (string ignoredType in filter.IgnoredTypes) {
+				if (!string.Equals(ignoredType, "Demo", StringComparison.OrdinalIgnoreCase)) {
+					return false;
+				}
+			}
+
+			return true;
+		}
+
 		internal bool FilterOnlyAllowsPackages(FilterConfig filter) {
 			if (filter.NoCostOnly) {
 				// NoCost is a property value that only applies to packages, so ignore all non-packages

--- a/FreePackages/PackageQueue/ActivationQueue.cs
+++ b/FreePackages/PackageQueue/ActivationQueue.cs
@@ -26,6 +26,10 @@ namespace FreePackages {
 
 		protected override Package? GetNextPackage() => BotCache.GetNextPackage(ActivationTypes);
 
+		// Held while a PlaytestCatalog fetch is running so we don't burn 401s from the stale
+		// persisted queue before the live set is refreshed. See PackageQueue.IsPaused.
+		protected override bool IsPaused => PackageHandler.ActivationsPausedGlobally;
+
 		protected override async Task<DateTime?> BeforeProcessing(Package package) {
 			// Rate limit reached
 			if (BotCache.NumActivationsPastPeriod() >= ActivationsPerPeriod) {

--- a/FreePackages/PackageQueue/ActivationQueue.cs
+++ b/FreePackages/PackageQueue/ActivationQueue.cs
@@ -14,6 +14,9 @@ namespace FreePackages {
 		internal const uint ActivationPeriodMinutes = 90; // Steam's imposed limit
 		internal readonly PackageFilter PackageFilter;
 		internal static readonly HashSet<EPackageType> ActivationTypes = [EPackageType.App, EPackageType.Sub, EPackageType.Playtest];
+		// App/Sub only — used while a PlaytestCatalog fetch is running so playtest claims are
+		// held (the persisted playtest queue is stale) but apps/subs keep activating.
+		internal static readonly HashSet<EPackageType> NonPlaytestActivationTypes = [EPackageType.App, EPackageType.Sub];
 		internal int ActivationsRemaining => BotCache.Packages.Where(x => ActivationTypes.Contains(x.Type)).Count();
 
 		internal ActivationQueue(Bot bot, BotCache botCache, bool pauseWhilePlaying, bool pauseWhileFarming, uint? packageLimit, PackageFilter packageFilter) : base(bot, botCache, pauseWhilePlaying, pauseWhileFarming) {
@@ -24,11 +27,11 @@ namespace FreePackages {
 			}
 		}
 
-		protected override Package? GetNextPackage() => BotCache.GetNextPackage(ActivationTypes);
-
-		// Held while a PlaytestCatalog fetch is running so we don't burn 401s from the stale
-		// persisted queue before the live set is refreshed. See PackageQueue.IsPaused.
-		protected override bool IsPaused => PackageHandler.ActivationsPausedGlobally;
+		// While a PlaytestCatalog fetch is running (PackageHandler.PlaytestsPausedGlobally) the
+		// persisted playtest queue is stale and would fire 401s, so skip playtests and only
+		// claim apps/subs. Once the fetch finishes the flag clears and the next tick (forced
+		// by ResumePlaytestActivations' nudge) picks playtests back up.
+		protected override Package? GetNextPackage() => BotCache.GetNextPackage(PackageHandler.PlaytestsPausedGlobally ? NonPlaytestActivationTypes : ActivationTypes);
 
 		protected override async Task<DateTime?> BeforeProcessing(Package package) {
 			// Rate limit reached

--- a/FreePackages/PackageQueue/PackageQueue.cs
+++ b/FreePackages/PackageQueue/PackageQueue.cs
@@ -207,7 +207,11 @@ namespace FreePackages {
 			Steam.PlaytestAccessResponse? response = await WebRequest.RequestPlaytestAccess(Bot, appID).ConfigureAwait(false);
 
 			if (response == null) {
-				// Playtest does not exist currently
+				// Playtest does not exist currently. The catalog said it was live, so this
+				// is a stale-catalog race (dev just hid the signup). Record it so we don't
+				// re-request within this membership epoch; it gets pruned only if it leaves
+				// the live set, and re-requested only if it re-enters.
+				BotCache.AddRequestedPlaytest(appID);
 				Bot.ArchiLogger.LogGenericDebug(String.Format(ArchiSteamFarm.Localization.Strings.BotAddLicense, String.Format("playtest/{0}", appID), Strings.Invalid));
 
 				return EResult.Invalid;
@@ -215,6 +219,7 @@ namespace FreePackages {
 
 			if (response.Success != 1) {
 				// Not sure if/when this happens
+				BotCache.AddRequestedPlaytest(appID);
 				Bot.ArchiLogger.LogGenericDebug(String.Format(ArchiSteamFarm.Localization.Strings.BotAddLicense, String.Format("playtest/{0}", appID), Strings.Failed));
 
 				return EResult.Invalid;
@@ -226,12 +231,16 @@ namespace FreePackages {
 
 				// This won't show up in our owned apps until we're accepted, save it so we don't attempt to join the playtest again
 				BotCache.AddWaitlistedPlaytest(appID);
+				BotCache.AddRequestedPlaytest(appID);
 
 				return EResult.OK;
 			}
 
 			// Access to unlimited playtest granted
 			Bot.ArchiLogger.LogGenericInfo(String.Format(ArchiSteamFarm.Localization.Strings.BotAddLicense, String.Format("playtest/{0}", appID), EResult.OK));
+
+			// Record so the catalog-proactive path doesn't re-enqueue while it stays live.
+			BotCache.AddRequestedPlaytest(appID);
 
 			return EResult.OK;
 		}

--- a/FreePackages/PackageQueue/PackageQueue.cs
+++ b/FreePackages/PackageQueue/PackageQueue.cs
@@ -16,6 +16,12 @@ namespace FreePackages {
 		private PackageFilter PackageFilter => PackageHandler.Handlers[Bot.BotName].PackageFilter;
 		private Timer Timer;
 
+		// Overridden by ActivationQueue to honor PackageHandler.ActivationsPausedGlobally —
+		// while a PlaytestCatalog fetch is in progress we hold all activations so the
+		// stale persisted queue doesn't fire a 401 storm before the live set is refreshed.
+		// RemovalQueue inherits the default (never paused).
+		protected virtual bool IsPaused => false;
+
 		internal PackageQueue(Bot bot, BotCache botCache, bool pauseWhilePlaying, bool pauseWhileFarming) {
 			Bot = bot;
 			BotCache = botCache;
@@ -33,6 +39,15 @@ namespace FreePackages {
 		}
 
 		private async Task ProcessQueue() {
+			// Hold activations while the PlaytestCatalog fetch is running (see IsPaused). Re-check
+			// shortly so we resume promptly once the fetch finishes and PackageHandler clears
+			// the flag (ResumeAllActivations also nudges the timer for an immediate re-check).
+			if (IsPaused) {
+				UpdateTimer(DateTime.Now.AddSeconds(5));
+
+				return;
+			}
+
 			if (!Bot.IsConnectedAndLoggedOn || !PackageFilter.Ready) {
 				UpdateTimer(DateTime.Now.AddMinutes(1));
 
@@ -309,5 +324,9 @@ namespace FreePackages {
 
 		private static int GetMillisecondsFromNow(DateTime then) => Math.Max(0, (int)(then - DateTime.Now).TotalMilliseconds);
 		private void UpdateTimer(DateTime then) => Timer?.Change(GetMillisecondsFromNow(then), Timeout.Infinite);
+
+		// Fire the queue tick immediately (used by ResumeAllActivations so activation queues
+		// resume right after a fetch instead of waiting up to their scheduled delay).
+		internal void Nudge() => Timer?.Change(0, Timeout.Infinite);
 	}
 }

--- a/FreePackages/PackageQueue/PackageQueue.cs
+++ b/FreePackages/PackageQueue/PackageQueue.cs
@@ -16,12 +16,6 @@ namespace FreePackages {
 		private PackageFilter PackageFilter => PackageHandler.Handlers[Bot.BotName].PackageFilter;
 		private Timer Timer;
 
-		// Overridden by ActivationQueue to honor PackageHandler.ActivationsPausedGlobally —
-		// while a PlaytestCatalog fetch is in progress we hold all activations so the
-		// stale persisted queue doesn't fire a 401 storm before the live set is refreshed.
-		// RemovalQueue inherits the default (never paused).
-		protected virtual bool IsPaused => false;
-
 		internal PackageQueue(Bot bot, BotCache botCache, bool pauseWhilePlaying, bool pauseWhileFarming) {
 			Bot = bot;
 			BotCache = botCache;
@@ -39,15 +33,6 @@ namespace FreePackages {
 		}
 
 		private async Task ProcessQueue() {
-			// Hold activations while the PlaytestCatalog fetch is running (see IsPaused). Re-check
-			// shortly so we resume promptly once the fetch finishes and PackageHandler clears
-			// the flag (ResumeAllActivations also nudges the timer for an immediate re-check).
-			if (IsPaused) {
-				UpdateTimer(DateTime.Now.AddSeconds(5));
-
-				return;
-			}
-
 			if (!Bot.IsConnectedAndLoggedOn || !PackageFilter.Ready) {
 				UpdateTimer(DateTime.Now.AddMinutes(1));
 
@@ -325,7 +310,7 @@ namespace FreePackages {
 		private static int GetMillisecondsFromNow(DateTime then) => Math.Max(0, (int)(then - DateTime.Now).TotalMilliseconds);
 		private void UpdateTimer(DateTime then) => Timer?.Change(GetMillisecondsFromNow(then), Timeout.Infinite);
 
-		// Fire the queue tick immediately (used by ResumeAllActivations so activation queues
+		// Fire the queue tick immediately (used by ResumePlaytestActivations so activation queues
 		// resume right after a fetch instead of waiting up to their scheduled delay).
 		internal void Nudge() => Timer?.Change(0, Timeout.Infinite);
 	}

--- a/FreePackages/WebRequest.cs
+++ b/FreePackages/WebRequest.cs
@@ -13,8 +13,15 @@ namespace FreePackages {
 		internal static async Task<Steam.UserData?> GetUserData(Bot bot) {
 			Uri request = new(ArchiWebHandler.SteamStoreURL, "/dynamicstore/userdata/");
 			ObjectResponse<Steam.UserData>? userDataResponse = await bot.ArchiWebHandler.UrlGetToJsonObjectWithSession<Steam.UserData>(request).ConfigureAwait(false);
-			
-			return userDataResponse?.Content;
+
+			if (userDataResponse?.Content == null) {
+				int statusCode = userDataResponse == null ? -1 : (int) userDataResponse.StatusCode;
+				bot.ArchiLogger.LogGenericError($"GetUserData failed for bot {bot.BotName}: dynamicstore/userdata response was null (HTTP {statusCode})");
+
+				return null;
+			}
+
+			return userDataResponse.Content;
 		}
 
 		internal static async Task<Steam.PlaytestAccessResponse?> RequestPlaytestAccess(Bot bot, uint appID) {
@@ -33,28 +40,71 @@ namespace FreePackages {
 			return accountLicensesResponse?.Content;
 		}
 
+		// Scrapes the bot's store root page for the embedded `data-userinfo="..."` JSON blob.
+		// This is inherently fragile: it depends on Steam's store markup, which can change
+		// without notice. When it breaks, `PackageFilter.Ready` never becomes true and the bot
+		// silently activates nothing — so we log the exact failure mode and retry once.
 		internal static async Task<Steam.UserInfo?> GetUserInfo(Bot bot) {
 			Uri request = new(ArchiWebHandler.SteamStoreURL, "");
-			HtmlDocumentResponse? storeResponse = await bot.ArchiWebHandler.UrlGetToHtmlDocumentWithSession(request).ConfigureAwait(false);
 
-			if (storeResponse == null || storeResponse.Content == null) {
-				return null;
-			}
+			// One retry with a short backoff: the store root occasionally returns an
+			// intermediate/login-challenge page on the first hit.
+			const int maxAttempts = 2;
+			for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+				HtmlDocumentResponse? storeResponse = await bot.ArchiWebHandler.UrlGetToHtmlDocumentWithSession(request).ConfigureAwait(false);
 
-			try {
-				Regex pageObjRegex = new Regex("data-userinfo=\"({[\\s\\S]*?})\"", RegexOptions.CultureInvariant);
-				Match match = pageObjRegex.Match(storeResponse.Content.Source.Text);
+				if (storeResponse == null) {
+					bot.ArchiLogger.LogGenericError($"GetUserInfo failed for bot {bot.BotName}: store response was null (attempt {attempt}/{maxAttempts})");
 
-				if (!match.Success) {
-					throw new Exception(String.Format(ArchiSteamFarm.Localization.Strings.ErrorIsEmpty, nameof(match)));
+					if (attempt < maxAttempts) {
+						await Task.Delay(2000).ConfigureAwait(false);
+
+						continue;
+					}
+
+					return null;
 				}
 
-				return match.Groups[1].Value.Replace("&quot;", "\"").ToJsonObject<Steam.UserInfo>();
-			} catch (Exception e) {
-				bot.ArchiLogger.LogGenericException(e);
+				if (storeResponse.Content == null) {
+					int statusCode = (int) storeResponse.StatusCode;
+					bot.ArchiLogger.LogGenericError($"GetUserInfo failed for bot {bot.BotName}: empty content (HTTP {statusCode}, attempt {attempt}/{maxAttempts})");
 
-				return null;
+					if (attempt < maxAttempts) {
+						await Task.Delay(2000).ConfigureAwait(false);
+
+						continue;
+					}
+
+					return null;
+				}
+
+				try {
+					Regex pageObjRegex = new Regex("data-userinfo=\"({[\\s\\S]*?})\"", RegexOptions.CultureInvariant);
+					Match match = pageObjRegex.Match(storeResponse.Content.Source.Text);
+
+					if (!match.Success) {
+						// Distinguish "page loaded but layout changed" from "page didn't load".
+						int textLength = storeResponse.Content.Source.Text?.Length ?? 0;
+						bot.ArchiLogger.LogGenericError($"GetUserInfo failed for bot {bot.BotName}: data-userinfo regex did not match (page length {textLength}, attempt {attempt}/{maxAttempts})");
+
+						if (attempt < maxAttempts) {
+							await Task.Delay(2000).ConfigureAwait(false);
+
+							continue;
+						}
+
+						return null;
+					}
+
+					return match.Groups[1].Value.Replace("&quot;", "\"").ToJsonObject<Steam.UserInfo>();
+				} catch (Exception e) {
+					bot.ArchiLogger.LogGenericException(e);
+
+					return null;
+				}
 			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
PICS doesn't expose whether a playtest's signup is currently open, so most `/ajaxrequestplaytestaccess` POSTs returned 401 ("no playtest for appID") and were re-issued on every PICS change. On one account over ~30 days this was ~5000+ `Invalid` results across ~2200 distinct apps, repeating each time the parent's PICS entry changed. There was no suppression for these (unlike waitlisted playtests), so they just kept coming back.

A TTL would reduce the noise but a playtest can open and close several times over a weekend — a fixed window risks missing a re-opening. Instead this uses Steam's own Playtests search category (`category1=989`) as the source of truth for "joinable right now".

## Playtest catalog

`PlaytestCatalog` (new, mirrors `ASFInfo`) fetches that category anonymously through `ASF.WebBrowser` once per hour, paginated 100/page (~31 GETs for the current ~3000 entries). The `data-ds-appid` on each result is the base game appID — the same value the plugin already posts to `/ajaxrequestplaytestaccess/<id>`. The category only lists apps whose signup is currently visible, so list membership is the re-trigger: a playtest that leaves the list (dev hid the signup) and later returns is requested again, every time.

- `HandlePlaytest` gates on the live set once a fetch has completed, so PICS no longer drives POSTs for closed playtests. Before the first successful fetch it keeps the old PICS-only behavior so a fresh start isn't starved.
- A catalog-proactive path enqueues any live playtest a bot hasn't already requested or waitlisted, catching playtests PICS never surfaced.
- PICS is kept for the `PlaytestMode` limited/unlimited filter and as an early-wake: every Beta-app PICS change calls `RequestRefresh` (debounced to the hourly cadence) so the live set reflects a newly opened playtest without waiting for the next cycle.
- `RequestedPlaytests` (new persisted set) suppresses re-requests within a membership epoch. `WaitlistedPlaytests` is reused for the waitlist.

### Fetch hardening (verified against the live endpoint)

- **Deterministic sort.** The original `sort_by=_ASC` (empty field) made Steam fall back to a non-deterministic order, so paginating by `start` returned overlapping slices and a full fetch collected only ~74% of `total_count`. `sort_by=Name_ASC` partitions cleanly: 100/page, zero overlap.
- **Page count cap is 100.** `count=200` returns the same 100 as `count=100`, so a full ~3000-entry fetch is 31 pages.
- **Burst cap.** Steam's anonymous-search burst limit is ~30 requests per ~5-minute sliding window. At 1s spacing all 31 pages land inside the window, so the 31st page was rejected every fetch. Pages are now spaced 12s so the 31 requests span ~6 min — past the window — and the final page comes through without the penalty. The same-page backoff (`MaxPageRetries=4`, `120s`) stays as a safety net if the window is longer than observed, instead of aborting the whole fetch at page 30.
- **Semaphore.** `DoUpdate` acquired `RefreshSemaphore` twice (left over from an outer try/catch); `SemaphoreSlim` is non-reentrant so the second acquire leaked the slot and every later fetch silently bailed. Now acquired once.
- **Per-request timeout** (30s) so a hung Steam GET can't hold the semaphore.
- **Stale-queue pruning.** `PrunePlaytestPackages` drops now-closed playtests from the activation queue so they don't drain one-by-one as 401 `Invalid`.
- **Completeness check.** A partial fetch (e.g. a markup change) — parsed < half of `total_count` — keeps the previous live set instead of wiping the suppression sets and re-requesting the whole catalog.
- **Pause scope.** Only PLAYTEST activations are paused for the duration of a fetch (apps/subs keep going) — the persisted playtest queue is the only stale part. `PauseAllActivations`/`ResumeAllActivations` renamed to `PausePlaytestActivations`/`ResumePlaytestActivations`, gate moved from `PackageQueue.IsPaused` into `ActivationQueue.GetNextPackage`.

Pruning only runs on a successful, complete fetch. A failed or partial fetch keeps the previous set — otherwise a transient failure would wipe the suppression and re-request the entire catalog.

## Reliability / observability

- The ASFinfo update used to `return` on the first line it couldn't parse, so one bad line in the gist discarded the rest. It now skips the line and keeps going, and resets if the gist shrinks below the last recorded position.
- `PICSHandler.FetchPICSChanges` and `ProductInfo.FetchProductInfo` picked one connected bot and dropped the whole batch if that call threw. They now snapshot the connected bots and try them in turn until one succeeds.
- `OnBotDisconnected` was a no-op. It now cancels any in-flight removable scan for the bot that dropped, so a disconnect mid-scan doesn't keep grinding against a dead session.
- `BotCache` kicked off `Utilities.InBackground(Save)` on every mutation — tens of thousands of threadpool tasks under a large PICS changelist. Saves now go through a one-shot debounce timer (5s). `SerializableFile`'s coalescing still handles concurrent saves; ASF has no shutdown hook for `IBotModules` so a final flush on exit isn't possible (noted in a comment).
- `IsReady` used to block `HandleChanges` for up to 120s. It now caps at 15s and logs which bots are still not ready, then proceeds. Not-ready bots early-return in their handlers and their changes stay queued.
- `WebRequest.GetUserInfo` scrapes the `data-userinfo` blob off the store root, which is fragile. On failure it retries once and logs the response length and the regex-miss case separately.
- `BotCache.UpdateSeenPackages` had a TODO around which `EPaymentMethod` values count as a free activation. It now counts `Complimentary` and `AutoGrant` and leaves out `GuestPass` (temporary) and `ActivationCode` (key).
- The license parsing in `dontremove` and `queuelicense` was duplicated; pulled into one `ParseLicenseEntries` helper.

## Tradeoff

The catalog-proactive path doesn't apply the limited/unlimited `PlaytestMode` filter — the catalog only gives base appIDs, and resolving `playtest_type` for each would need an extra PICS fetch per playtest. The PICS path still applies it for playtests it discovers. The first run after deploying enqueues the whole live set per bot (throttled by the existing activation queue) — that's the "grab everything currently open" behavior, intended.

## Tests / compat

Parser (`data-ds-appid` from a fixture), `IsFetchComplete` safety net, and prune behavior (a playtest leaving the set is removed; staying is kept; empty sets are safe). 50/50 green. Builds clean (0 errors). `TreatWarningsAsErrors` left as `false` (the template ships that way; the plugin carries pre-existing analyzer warnings this PR doesn't try to clear). Backward compatible — old `*.FreePackages.db` files load with an empty `RequestedPlaytests`; no config or cache schema changes.